### PR TITLE
Use url_for instead of request.url in security next param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - :warning: **breaking change**: Package renamming and new repository [#1](https://github.com/etalab/udata-front/pull/1):
   - udata-gouvfr is now udata-front
 - Update feedparser following setuptools 58.0.2 release that drops support for `use_2to3` [#6](https://github.com/etalab/udata-front/pull/6)
+- Fix next value on login to prevent infinite loop [#4](https://github.com/etalab/udata-front/pull/4)
 
 ## 3.1.0 (2021-08-31)
 

--- a/udata_front/tests/views/test_security.py
+++ b/udata_front/tests/views/test_security.py
@@ -1,0 +1,23 @@
+from flask import url_for
+
+from udata.core.dataset.factories import DatasetFactory
+from udata_front.tests import GouvFrSettings
+from udata_front.tests.frontend import GouvfrFrontTestCase
+
+
+class SecurityViewsTest(GouvfrFrontTestCase):
+    settings = GouvFrSettings
+
+    def test_security_login_next_home(self):
+        '''Login should redirect to the correct next endpoint: homepage'''
+        with self.app.test_request_context(''):
+            response = self.get(url_for('site.home'))
+            assert b'<a href="/en/login?next=%2Fen%2F"' in response.data
+
+    def test_security_login_next_datasets(self):
+        '''Login should redirect to the correct next endpoint: dataset'''
+        with self.app.test_request_context(''):
+            self.app.preprocess_request()
+            dataset = DatasetFactory(slug="dataset-slug")
+            response = self.get(url_for('datasets.show', dataset=dataset))
+            assert b'<a href="/en/login?next=%2Fen%2Fdatasets%2Fdataset-slug%2F"' in response.data

--- a/udata_front/tests/views/test_security.py
+++ b/udata_front/tests/views/test_security.py
@@ -21,3 +21,10 @@ class SecurityViewsTest(GouvfrFrontTestCase):
             dataset = DatasetFactory(slug="dataset-slug")
             response = self.get(url_for('datasets.show', dataset=dataset))
             assert b'<a href="/en/login?next=%2Fen%2Fdatasets%2Fdataset-slug%2F"' in response.data
+
+    def test_security_login_next_exception_site_home(self):
+        '''Login should redirect to the homepage if current request has an exception'''
+        with self.app.test_request_context(''):
+            self.app.preprocess_request()
+            response = self.get(url_for('datasets.show', dataset='dataset-not-found'))
+            assert b'<a href="/en/login?next=%2Fen%2F"' in response.data

--- a/udata_front/theme/gouvfr/templates/header.html
+++ b/udata_front/theme/gouvfr/templates/header.html
@@ -54,10 +54,10 @@
                         title="{{ _('Logout') }}">{% include theme('svg/login.svg') %}{{ _('Logout') }}
                     </a>
                     {% else %}
-                    <a href="{{ url_for('security.login', next=request.endpoint) }}"
+                    <a href="{{ url_for('security.login', next=url_for(request.endpoint, **request.view_args)) }}"
                         title="{{ _('Log in') }}">{% include theme('svg/login.svg') %}{{ _('Log in') }}
                     </a>
-                    <a href="{{ url_for('security.register', next=request.endpoint) }}"
+                    <a href="{{ url_for('security.register', next=url_for(request.endpoint, **request.view_args)) }}"
                         title="{{ _('Sign up') }}">{% include theme('svg/register.svg') %}{{ _("Sign up") }}
                     </a>
                     {% endif %}

--- a/udata_front/theme/gouvfr/templates/header.html
+++ b/udata_front/theme/gouvfr/templates/header.html
@@ -1,4 +1,5 @@
 {% set banner_activated = config['BANNER_ACTIVATED'] %}
+{% set next_url = url_for(request.endpoint, **request.view_args) if not request.routing_exception else url_for('site.home') %}
 {% if banner_activated %}
 {% block banner %}
     {% set banner_message = config['BANNER_HTML_CONTENT_FR'] if g.lang_code == "fr" else config['BANNER_HTML_CONTENT_EN'] %}
@@ -54,10 +55,10 @@
                         title="{{ _('Logout') }}">{% include theme('svg/login.svg') %}{{ _('Logout') }}
                     </a>
                     {% else %}
-                    <a href="{{ url_for('security.login', next=url_for(request.endpoint, **request.view_args)) }}"
+                    <a href="{{ url_for('security.login', next=next_url) }}"
                         title="{{ _('Log in') }}">{% include theme('svg/login.svg') %}{{ _('Log in') }}
                     </a>
-                    <a href="{{ url_for('security.register', next=url_for(request.endpoint, **request.view_args)) }}"
+                    <a href="{{ url_for('security.register', next=next_url) }}"
                         title="{{ _('Sign up') }}">{% include theme('svg/register.svg') %}{{ _("Sign up") }}
                     </a>
                     {% endif %}

--- a/udata_front/theme/gouvfr/templates/header.html
+++ b/udata_front/theme/gouvfr/templates/header.html
@@ -54,10 +54,10 @@
                         title="{{ _('Logout') }}">{% include theme('svg/login.svg') %}{{ _('Logout') }}
                     </a>
                     {% else %}
-                    <a href="{{ url_for('security.login', next=request.url) }}"
+                    <a href="{{ url_for('security.login', next=request.endpoint) }}"
                         title="{{ _('Log in') }}">{% include theme('svg/login.svg') %}{{ _('Log in') }}
                     </a>
-                    <a href="{{ url_for('security.register', next=request.url) }}"
+                    <a href="{{ url_for('security.register', next=request.endpoint) }}"
                         title="{{ _('Sign up') }}">{% include theme('svg/register.svg') %}{{ _("Sign up") }}
                     </a>
                     {% endif %}

--- a/udata_front/theme/gouvfr/templates/security/login_user.html
+++ b/udata_front/theme/gouvfr/templates/security/login_user.html
@@ -13,7 +13,7 @@
                         <div class="mt-lg">
                             <p class="fs-sm mb-sm">
                                 {{ _('Forgot your password?') }}
-                                <a href="{{ url_for('security.forgot_password', next=request.endoint) }}">
+                                <a href="{{ url_for('security.forgot_password', next=url_for(request.endpoint, **request.view_args)) }}">
                                     {{ _('Recover your password') }}
                                 </a>
                             </p>
@@ -36,7 +36,7 @@
                 <h3 class="fs-sm mb-sm">
                     {{ _('Don\'t have an account?')}}
                 </h3>
-                <a title="{{ _('Sign up') }}" href="{{ url_for('security.register', next=request.endpoint) }}"
+                <a title="{{ _('Sign up') }}" href="{{ url_for('security.register', next=url_for(request.endpoint, **request.view_args)) }}"
                     class="btn btn-primary btn-block btn-lg">
                     {{ _('Create an account') }}
                 </a>

--- a/udata_front/theme/gouvfr/templates/security/login_user.html
+++ b/udata_front/theme/gouvfr/templates/security/login_user.html
@@ -13,7 +13,7 @@
                         <div class="mt-lg">
                             <p class="fs-sm mb-sm">
                                 {{ _('Forgot your password?') }}
-                                <a href="{{ url_for('security.forgot_password', next=request.url) }}">
+                                <a href="{{ url_for('security.forgot_password', next=request.endoint) }}">
                                     {{ _('Recover your password') }}
                                 </a>
                             </p>
@@ -36,7 +36,7 @@
                 <h3 class="fs-sm mb-sm">
                     {{ _('Don\'t have an account?')}}
                 </h3>
-                <a title="{{ _('Sign up') }}" href="{{ url_for('security.register', next=request.url) }}"
+                <a title="{{ _('Sign up') }}" href="{{ url_for('security.register', next=request.endpoint) }}"
                     class="btn btn-primary btn-block btn-lg">
                     {{ _('Create an account') }}
                 </a>

--- a/udata_front/theme/gouvfr/templates/security/login_user.html
+++ b/udata_front/theme/gouvfr/templates/security/login_user.html
@@ -1,5 +1,6 @@
 {% extends theme('base.html') %}
 {% import theme('macros/forms.html') as forms with context %}
+{% set next_url = url_for(request.endpoint, **request.view_args) if not request.routing_exception else url_for('site.home') %}
 
 {% block content %}
 <section class="py-xl py-lg-lg bg-grey-50">
@@ -13,7 +14,7 @@
                         <div class="mt-lg">
                             <p class="fs-sm mb-sm">
                                 {{ _('Forgot your password?') }}
-                                <a href="{{ url_for('security.forgot_password', next=url_for(request.endpoint, **request.view_args)) }}">
+                                <a href="{{ url_for('security.forgot_password', next=next_url) }}">
                                     {{ _('Recover your password') }}
                                 </a>
                             </p>
@@ -36,7 +37,7 @@
                 <h3 class="fs-sm mb-sm">
                     {{ _('Don\'t have an account?')}}
                 </h3>
-                <a title="{{ _('Sign up') }}" href="{{ url_for('security.register', next=url_for(request.endpoint, **request.view_args)) }}"
+                <a title="{{ _('Sign up') }}" href="{{ url_for('security.register', next=next_url) }}"
                     class="btn btn-primary btn-block btn-lg">
                     {{ _('Create an account') }}
                 </a>

--- a/udata_front/theme/gouvfr/templates/territories/territory.html
+++ b/udata_front/theme/gouvfr/templates/territories/territory.html
@@ -36,7 +36,7 @@
                     {{ _('If you want your datasets to appear in that list, the geographical zone associated must be the exact same one of that territory (%(code)s).', code=territory.code) }}
                     {% else %}
                     {{ _('You want to add your own datasets to that list?') }}<br />
-                    <a title="{{ _('Log in / Sign up') }}" href="{{ url_for('security.login', next=request.endpoint) }}">
+                    <a title="{{ _('Log in / Sign up') }}" href="{{ url_for('security.login', next=url_for(request.endpoint, **request.view_args)) }}">
                         {{ _('Log in') }}</a>
                     {{ _('and create resources for that territory.') }}
                     {% endif %}

--- a/udata_front/theme/gouvfr/templates/territories/territory.html
+++ b/udata_front/theme/gouvfr/templates/territories/territory.html
@@ -36,7 +36,7 @@
                     {{ _('If you want your datasets to appear in that list, the geographical zone associated must be the exact same one of that territory (%(code)s).', code=territory.code) }}
                     {% else %}
                     {{ _('You want to add your own datasets to that list?') }}<br />
-                    <a title="{{ _('Log in / Sign up') }}" href="{{ url_for('security.login', next=request.url) }}">
+                    <a title="{{ _('Log in / Sign up') }}" href="{{ url_for('security.login', next=request.endpoint) }}">
                         {{ _('Log in') }}</a>
                     {{ _('and create resources for that territory.') }}
                     {% endif %}

--- a/udata_front/theme/gouvfr/templates/territories/territory.html
+++ b/udata_front/theme/gouvfr/templates/territories/territory.html
@@ -1,4 +1,5 @@
 {% extends theme("layouts/1-column.html") %}
+{% set next_url = url_for(request.endpoint, **request.view_args) if not request.routing_exception else url_for('site.home') %}
 
 {% set bundle = 'territory' %}
 {% set logo = territory.logo_url(external=True) or theme_static('img/placeholder_territory.png', external=True) %}
@@ -36,7 +37,7 @@
                     {{ _('If you want your datasets to appear in that list, the geographical zone associated must be the exact same one of that territory (%(code)s).', code=territory.code) }}
                     {% else %}
                     {{ _('You want to add your own datasets to that list?') }}<br />
-                    <a title="{{ _('Log in / Sign up') }}" href="{{ url_for('security.login', next=url_for(request.endpoint, **request.view_args)) }}">
+                    <a title="{{ _('Log in / Sign up') }}" href="{{ url_for('security.login', next=next_url) }}">
                         {{ _('Log in') }}</a>
                     {{ _('and create resources for that territory.') }}
                     {% endif %}


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/509.

Uses `url_for(request.endpoint, **request.view_args)` instead of `request.url`.

Some security pages in `udata` also use `next=request.url`. Not sure if the same issue could happen there ?