### PR TITLE
Pin setuptools==53.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,10 @@ jobs:
       - run:
           name: Create venv and install pip-tools
           command: |
-            virtualenv venv
+            virtualenv --no-setuptools venv
             source venv/bin/activate
+            # FIXME set setuptools version due to 53.0.2 release
+            pip install setuptools==53.0.0
             pip install pip-tools
       - run:
           name: Upgrade udata to latest pypi release if tagged release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - :warning: **breaking change**: Package renamming and new repository [#1](https://github.com/etalab/udata-front/pull/1):
   - udata-gouvfr is now udata-front
+- pin setuptools==53.0.0 due to `use_2to3` support being dropped [#5](https://github.com/etalab/udata-front/pull/5)
 
 ## 3.1.0 (2021-08-31)
 


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/508.

Sadly, the [patch](https://github.com/pypa/setuptools/issues/2775) didn't fix our issue, because we do use a lib that uses `use_2to3=True`.

We'll need to update our dependencies that rely on `use_2to3=True` in the future (https://github.com/etalab/data.gouv.fr/issues/512).
