### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - :warning: **breaking change**: Package renamming and new repository [#1](https://github.com/etalab/udata-front/pull/1):
   - udata-gouvfr is now udata-front
+- Update feedparser following setuptools 58.0.2 release that drops support for `use_2to3` [#6](https://github.com/etalab/udata-front/pull/6)
 
 ## 3.1.0 (2021-08-31)
 

--- a/requirements/install.in
+++ b/requirements/install.in
@@ -1,5 +1,5 @@
 -c udata.pip
 
-feedparser==5.2.1
+feedparser==6.0.8
 python-frontmatter==1.0.0
 sentry-sdk[flask] >= 1.1.0

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -16,7 +16,7 @@ click==7.0
     # via
     #   -c requirements/udata.pip
     #   flask
-feedparser==5.2.1
+feedparser==6.0.8
     # via -r requirements/install.in
 flask==1.1.4
     # via
@@ -40,6 +40,8 @@ pyyaml==5.4.1
     # via python-frontmatter
 sentry-sdk[flask]==1.3.1
     # via -r requirements/install.in
+sgmllib3k==1.0.0
+    # via feedparser
 urllib3==1.25.11
     # via
     #   -c requirements/udata.pip

--- a/requirements/udata.in
+++ b/requirements/udata.in
@@ -1,1 +1,1 @@
-udata@git+https://github.com/opendatateam/udata.git
+https://21428-19141754-gh.circle-artifacts.com/0/dist/udata-3.1.1.dev21428-py2.py3-none-any.whl

--- a/requirements/udata.in
+++ b/requirements/udata.in
@@ -1,1 +1,1 @@
-https://21428-19141754-gh.circle-artifacts.com/0/dist/udata-3.1.1.dev21428-py2.py3-none-any.whl
+udata@git+https://github.com/opendatateam/udata.git

--- a/requirements/udata.pip
+++ b/requirements/udata.pip
@@ -196,7 +196,7 @@ markupsafe==2.0.1
     #   udata
 mistune==0.8.4
     # via udata
-mongoengine==0.18.2
+mongoengine==0.20.0
     # via
     #   celerybeat-mongo
     #   flask-mongoengine
@@ -244,11 +244,7 @@ pytz==2019.3
     #   celery
     #   flask-restplus
     #   udata
-rdflib==5.0.0
-    # via
-    #   rdflib-jsonld
-    #   udata
-rdflib-jsonld==0.5.0
+rdflib==6.0.0
     # via udata
 redis==3.3.11
     # via
@@ -277,9 +273,7 @@ six==1.16.0
     #   flask-restplus
     #   isodate
     #   jsonschema
-    #   mongoengine
     #   python-dateutil
-    #   rdflib
     #   udata
     #   wtforms-json
 speaklater==1.3
@@ -298,7 +292,7 @@ typing-extensions==3.10.0.0
     # via
     #   importlib-metadata
     #   udata
-git+https://github.com/opendatateam/udata.git
+https://21428-19141754-gh.circle-artifacts.com/0/dist/udata-3.1.1.dev21428-py2.py3-none-any.whl
     # via -r requirements/udata.in
 ujson==1.35
     # via udata

--- a/requirements/udata.pip
+++ b/requirements/udata.pip
@@ -292,7 +292,7 @@ typing-extensions==3.10.0.0
     # via
     #   importlib-metadata
     #   udata
-https://21428-19141754-gh.circle-artifacts.com/0/dist/udata-3.1.1.dev21428-py2.py3-none-any.whl
+git+https://github.com/opendatateam/udata.git
     # via -r requirements/udata.in
 ujson==1.35
     # via udata

--- a/udata_front/theme/gouvfr/__init__.py
+++ b/udata_front/theme/gouvfr/__init__.py
@@ -33,7 +33,7 @@ RE_STRIP_TAGS = re.compile(r'</?(img|br|p|div|ul|li|ol)[^<>]*?>', re.I | re.M)
 
 # Add some html5 allowed attributes
 EXTRA_ATTRIBUTES = ('srcset', 'sizes')
-feedparser._HTMLSanitizer.acceptable_attributes.update(set(EXTRA_ATTRIBUTES))
+feedparser.sanitizer._HTMLSanitizer.acceptable_attributes.update(set(EXTRA_ATTRIBUTES))
 
 # Wordpress ATOM timeout
 WP_TIMEOUT = 5


### PR DESCRIPTION
See also https://github.com/opendatateam/udata/pull/2660.

Use udata artifact with updated dependencies to test on udata-front.
- [x] pin udata back to master

Update `feedparser`. No error or breaking were encountered yet ([changelog](https://github.com/kurtmckee/feedparser/blob/develop/CHANGELOG.rst)). 