### PR TITLE
Remove request context on test_security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   - udata-gouvfr is now udata-front
 - Update feedparser following setuptools 58.0.2 release that drops support for `use_2to3` [#6](https://github.com/etalab/udata-front/pull/6)
 - Show correct number of latest reuses on homepage [#3](https://github.com/etalab/udata-front/pull/3)
-- Fix next value on login to prevent infinite loop [#4](https://github.com/etalab/udata-front/pull/4)
+- Fix next value on login to prevent infinite loop [#4](https://github.com/etalab/udata-front/pull/4) [#8](https://github.com/etalab/udata-front/pull/8)
 
 ## Previous udata-gouvfr changelog
 

--- a/udata_front/tests/views/test_security.py
+++ b/udata_front/tests/views/test_security.py
@@ -10,21 +10,16 @@ class SecurityViewsTest(GouvfrFrontTestCase):
 
     def test_security_login_next_home(self):
         '''Login should redirect to the correct next endpoint: homepage'''
-        with self.app.test_request_context(''):
-            response = self.get(url_for('site.home'))
-            assert b'<a href="/en/login?next=%2Fen%2F"' in response.data
+        response = self.get(url_for('site.home'))
+        assert b'<a href="/en/login?next=%2Fen%2F"' in response.data
 
     def test_security_login_next_datasets(self):
         '''Login should redirect to the correct next endpoint: dataset'''
-        with self.app.test_request_context(''):
-            self.app.preprocess_request()
-            dataset = DatasetFactory(slug="dataset-slug")
-            response = self.get(url_for('datasets.show', dataset=dataset))
-            assert b'<a href="/en/login?next=%2Fen%2Fdatasets%2Fdataset-slug%2F"' in response.data
+        dataset = DatasetFactory(slug="dataset-slug")
+        response = self.get(url_for('datasets.show', dataset=dataset))
+        assert b'<a href="/en/login?next=%2Fen%2Fdatasets%2Fdataset-slug%2F"' in response.data
 
     def test_security_login_next_exception_site_home(self):
         '''Login should redirect to the homepage if current request has an exception'''
-        with self.app.test_request_context(''):
-            self.app.preprocess_request()
-            response = self.get(url_for('datasets.show', dataset='dataset-not-found'))
-            assert b'<a href="/en/login?next=%2Fen%2F"' in response.data
+        response = self.get(url_for('datasets.show', dataset='dataset-not-found'))
+        assert b'<a href="/en/login?next=%2Fen%2F"' in response.data


### PR DESCRIPTION
Following tests introduced in #4, we had a context request fail on CI (not reproduced yet).

Thought we needed to set a request context, but seems like it's not necessary here, let's remove it if it is not needed and may be responsible for CI failure.