### PR TITLE
Add a Request Membership action on organization page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Add read only mode back on frontend [#10](https://github.com/etalab/udata-front/pull/10)
+- Add a request membership action on organization page [#12](https://github.com/etalab/udata-front/pull/12)
 
 ## 1.0.0 (2021-09-16)
 

--- a/theme/js/components/organization/request-membership.vue
+++ b/theme/js/components/organization/request-membership.vue
@@ -37,13 +37,11 @@ data() {
       this.$api.post("organizations/" + this.orga + "/membership/", {comment: this.comment})
           .then(data => {
             alert(this.$t('A request has been sent to the administrators'));
+            window.location.reload();
         })
         .catch(error => {
             alert(this.$t('Error while requesting membership'));
             log.error(error);
-        })
-        .finally(()=> {
-            window.location.reload();
         });
       }
   }

--- a/theme/js/components/organization/request-membership.vue
+++ b/theme/js/components/organization/request-membership.vue
@@ -32,7 +32,7 @@ data() {
 
       this.$auth(this.$t("You must be connected to join an organization."));
 
-      this.comment = prompt(this.$t('You can add some details here for your membership request.'))
+      this.comment = prompt(this.$t('You can add some details here for your membership request.'));
 
       this.$api.post("organizations/" + this.orga + "/membership/", {comment: this.comment})
           .then(data => {

--- a/theme/js/components/organization/request-membership.vue
+++ b/theme/js/components/organization/request-membership.vue
@@ -1,0 +1,48 @@
+<!--
+---
+name: RequestMembership
+category: Interactions
+---
+
+# Request Membership
+
+A simple request membership prompt.
+-->
+
+<template>
+    <li class="my-md">
+        <a @click.prevent="JoinOrga"
+      class="nav-link">{{ $t('Ask to join the organization as a producer') }}</a>
+    </li>
+</template>
+
+<script>
+
+export default {
+  props: {
+    orga: String,
+  },
+data() {
+    return {
+        comment: '',
+    };
+},
+  methods: {
+    JoinOrga: function () {
+
+      this.$auth(this.$t("You must be connected to join an organization."));
+
+      this.comment = prompt(this.$t('You can add some details here for your membership request.'))
+
+      this.$api.post("organizations/" + this.orga + "/membership/", {comment: this.comment})
+          .then(data => {
+              alert(this.$t('A request has been sent to the administrators'));
+          })
+          .catch(error => {
+              alert(this.$t('Error while requesting membership'));
+              log.error(error);
+          });
+      }
+  }
+};
+</script>

--- a/theme/js/components/organization/request-membership.vue
+++ b/theme/js/components/organization/request-membership.vue
@@ -36,12 +36,15 @@ data() {
 
       this.$api.post("organizations/" + this.orga + "/membership/", {comment: this.comment})
           .then(data => {
-              alert(this.$t('A request has been sent to the administrators'));
-          })
-          .catch(error => {
-              alert(this.$t('Error while requesting membership'));
-              log.error(error);
-          });
+            alert(this.$t('A request has been sent to the administrators'));
+        })
+        .catch(error => {
+            alert(this.$t('Error while requesting membership'));
+            log.error(error);
+        })
+        .finally(()=> {
+            window.location.reload();
+        });
       }
   }
 };

--- a/theme/js/index.js
+++ b/theme/js/index.js
@@ -4,6 +4,7 @@ import Threads from "./components/discussions/threads.vue";
 import Suggest from "./components/search/suggest-box";
 import Search from "./components/search/search";
 import FollowButton from "./components/utils/follow-button";
+import RequestMembership from "./components/organization/request-membership";
 
 import Tabs from "./components/vanilla/tabs";
 import Accordion from "./components/vanilla/accordion";
@@ -39,6 +40,7 @@ app.component("discussion-threads", Threads);
 app.component("suggest", Suggest);
 app.component("search", Search);
 app.component("follow-button", FollowButton);
+app.component("request-membership", RequestMembership);
 
 //We keep the div HTML from before trying to mount the VueJS App
 const previousHtml = document.querySelector("#app").innerHTML;

--- a/udata_front/theme/gouvfr/templates/organization/display.html
+++ b/udata_front/theme/gouvfr/templates/organization/display.html
@@ -11,7 +11,7 @@
     'keywords': [_('organization')],
     'robots': 'noindex, nofollow' if is_hidden else '',
 } %}
-
+{% set read_only_mode = config.READ_ONLY_MODE %}
 
 {% set bundle = 'organization' %}
 
@@ -157,7 +157,7 @@
                 <div class="col-6 col-md-12  my-md-lg">
                     <h3>{{ _('Actions') }}</h3>
                     <ul class="nav-list">
-                        {% if can_edit %}
+                        {% if can_edit and not read_only_mode %}
                         <li class="my-md">
                             <a class="nav-link"
                                 href="{{ url_for('admin.index', path='organization/{id}/'.format(id=org.id)) }}">{{ _('Modify information') }}</a>
@@ -171,12 +171,12 @@
                         {% set member = org.member(current_user) %}
                         {% if not member %}
                             {% set pending_request = org.pending_request(current_user) %}
-                            {% if not pending_request %}
+                            {% if not pending_request and not read_only_mode %}
                             <li class="my-md">
                                 <request-membership orga='{{org.id}}'>
                                 </request-membership>
                             </li>
-                            {% else %}
+                            {% elif pending_request %}
                             <li class="my-md">
                                 <span
                                 class="f-light f-italic">{{ _('Pending request to join this organization') }}</a>

--- a/udata_front/theme/gouvfr/templates/organization/display.html
+++ b/udata_front/theme/gouvfr/templates/organization/display.html
@@ -167,6 +167,24 @@
                             <a href="{{ url_for('organizations.datasets_csv', org=org) }}"
                                 class="nav-link">{{ _('Download list of datasets as csv file') }}</a>
                         </li>
+
+                        {% set member = org.member(current_user) %}
+                        {% if not member %}
+                            {% set pending_request = org.pending_request(current_user) %}
+                            {% if not pending_request %}
+                            <li class="my-md">
+                                <request-membership orga='{{org.id}}'>
+                                </request-membership>
+                            </li>
+                            {% else %}
+                            <li class="my-md">
+                                <span
+                                class="f-light f-italic">{{ _('Pending request to join this organization') }}</a>
+                            </li>
+                            {% endif %}
+                        {% endif %}
+
+
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/438.

Used a simple prompt. See the following:

![image](https://user-images.githubusercontent.com/28541902/134208376-3aaa2076-aac9-4dec-aed7-a5b4d5c6187d.png)
![image](https://user-images.githubusercontent.com/28541902/134208432-5a41d58e-b730-4b98-8045-825039ed6786.png)
![image](https://user-images.githubusercontent.com/28541902/134208492-266e7ead-ef40-48d8-81d5-3cf232513e31.png)
![image](https://user-images.githubusercontent.com/28541902/134208582-d072e31a-d4cb-4fe6-ba05-486fa376344c.png)

For now, the pending status is not updated dynamically.
