### PR TITLE
Fix temporal coverage order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add read only mode back on frontend [#10](https://github.com/etalab/udata-front/pull/10)
 - Add a request membership action on organization page [#12](https://github.com/etalab/udata-front/pull/12)
 - Unset vue delimiters used in html templates to prevent injections [#11](https://github.com/etalab/udata-front/pull/11)
+- Fix temporal coverage order in search results metadata [#14](https://github.com/etalab/udata-front/pull/14)
 
 ## 1.0.0 (2021-09-16)
 

--- a/theme/js/components/dataset/search-result.vue
+++ b/theme/js/components/dataset/search-result.vue
@@ -33,7 +33,7 @@ Vue. -->
     <dl class="card-hover">
       <div v-if="temporal_coverage">
         <dt>{{ $t("Temporal coverage") }}</dt>
-        <dd>{{ Object.values(temporal_coverage).join(" - ") }}</dd>
+        <dd>{{ temporal_coverage.start + " - " + temporal_coverage.end }}</dd>
       </div>
       <div v-if="frequency">
         <dt>{{ $t("Frequency") }}</dt>
@@ -77,7 +77,7 @@ export default {
     organization: Object,
     owner: Object,
     description: String,
-    temporal_coverage: String,
+    temporal_coverage: Object,
     frequency: String,
     spatial: Object,
     metrics: Object,


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/556.

Use the fields `start` and `end` from temporal coverage (https://github.com/opendatateam/udata/blob/369d27e7efcf8dc80aec49e3902513128a704246/udata/core/dataset/api_fields.py#L90).