### PR TITLE
Override oauth route to serve udata-front template

### DIFF
--- a/udata_front/frontend/__init__.py
+++ b/udata_front/frontend/__init__.py
@@ -90,7 +90,7 @@ def _load_views(app, module):
 
 
 VIEWS = ['gouvfr', 'dataset', 'organization', 'follower', 'post',
-         'reuse', 'site', 'territories', 'topic', 'user']
+         'reuse', 'site', 'territories', 'topic', 'user', 'oauth']
 
 
 def init_app(app):

--- a/udata_front/views/oauth.py
+++ b/udata_front/views/oauth.py
@@ -1,0 +1,35 @@
+from authlib.integrations.flask_oauth2 import AuthorizationServer
+from authlib.oauth2 import OAuth2Error
+from flask import request
+
+from udata.auth import current_user, login_required
+from udata.i18n import I18nBlueprint
+
+from udata_front import theme
+
+
+blueprint = I18nBlueprint('oauth_udata_front', __name__, url_prefix='/oauth')
+oauth = AuthorizationServer()
+
+
+@blueprint.route('/authorize', methods=['GET'])
+@login_required
+def authorize(*args, **kwargs):
+    '''Override /authorize GET route to render udata-front template'''
+    if request.method == 'GET':
+        try:
+            grant = oauth.validate_consent_request(end_user=current_user)
+        except OAuth2Error as error:
+            return error.error
+        # Bypass authorization screen for internal clients
+        if grant.client.internal:
+            return oauth.create_authorization_response(grant_user=current_user)
+        return theme.render('api/oauth_authorize.html', grant=grant)
+    elif request.method == 'POST':
+        accept = 'accept' in request.form
+        decline = 'decline' in request.form
+        if accept and not decline:
+            grant_user = current_user
+        else:
+            grant_user = None
+        return oauth.create_authorization_response(grant_user=grant_user)

--- a/udata_front/views/oauth.py
+++ b/udata_front/views/oauth.py
@@ -1,6 +1,5 @@
 from authlib.integrations.flask_oauth2 import AuthorizationServer
 from authlib.oauth2 import OAuth2Error
-from flask import request
 
 from udata.auth import current_user, login_required
 from udata.i18n import I18nBlueprint

--- a/udata_front/views/oauth.py
+++ b/udata_front/views/oauth.py
@@ -16,20 +16,11 @@ oauth = AuthorizationServer()
 @login_required
 def authorize(*args, **kwargs):
     '''Override /authorize GET route to render udata-front template'''
-    if request.method == 'GET':
-        try:
-            grant = oauth.validate_consent_request(end_user=current_user)
-        except OAuth2Error as error:
-            return error.error
-        # Bypass authorization screen for internal clients
-        if grant.client.internal:
-            return oauth.create_authorization_response(grant_user=current_user)
-        return theme.render('api/oauth_authorize.html', grant=grant)
-    elif request.method == 'POST':
-        accept = 'accept' in request.form
-        decline = 'decline' in request.form
-        if accept and not decline:
-            grant_user = current_user
-        else:
-            grant_user = None
-        return oauth.create_authorization_response(grant_user=grant_user)
+    try:
+        grant = oauth.validate_consent_request(end_user=current_user)
+    except OAuth2Error as error:
+        return error.error
+    # Bypass authorization screen for internal clients
+    if grant.client.internal:
+        return oauth.create_authorization_response(grant_user=current_user)
+    return theme.render('api/oauth_authorize.html', grant=grant)


### PR DESCRIPTION
Related to https://github.com/etalab/data.gouv.fr/issues/466.

This is a proposal to override the `/authorize` route in `udata-front` to render the udata-front template if the plugin is loaded.

It didn't appear to be necessary in our case, but we could look to make sure to unregister the udata `/authorize` route ([example from stackoverflow](https://stackoverflow.com/a/49830875)).