### PR TITLE
Set an explicit color for each thread

### DIFF
--- a/theme/less/components/discussions.less
+++ b/theme/less/components/discussions.less
@@ -219,6 +219,7 @@ You can use a discussion creation button too.
 .discussions-wrapper {
     .thread-wrapper {
         .bg-beige;
+        .color-grey-350;
         margin-top: @spacing-md;
 
         .thread-header {


### PR DESCRIPTION
Otherwise the `section.text-white` overloads the implicit text color.

## Before/After

When adding manually .text-grey-350 to the first thread element

![image](https://user-images.githubusercontent.com/138627/139244604-50962d9f-0295-4584-ab6a-dcda558737d8.png)

As seen on: https://www.data.gouv.fr/fr/posts/suivi-des-sorties-septembre-2021/