### PR TITLE
Update oauth page style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@
 - Standardize reuse page similar to dataset page navigation quickfixes [#31](https://github.com/etalab/udata-front/pull/31)
 - Move template hook logic to udata and add oauth hooks [#29](https://github.com/etalab/udata-front/pull/29)
 - Add resources pagination dataset page and use DSFR pagination [#30](https://github.com/etalab/udata-front/pull/30)
+- Style oauth page [#34](https://github.com/etalab/udata-front/pull/34)
 
 ## 1.1.1 (2021-10-22)
 
 - Update README to reflect front changes [#17](https://github.com/etalab/udata-front/pull/17)
 - Add Participate banner in the footer [#24](https://github.com/etalab/udata-front/pull/24)
-- Fix min-heigth used in posts images to center them [#23](https://github.com/etalab/udata-front/pull/23)
+- Fix min-height used in posts images to center them [#23](https://github.com/etalab/udata-front/pull/23)
 - Update dataset page with navigation quickfixes and add DSFR components [#18](https://github.com/etalab/udata-front/pull/18)
 - Implement feedbacks on quickfixes [#26](https://github.com/etalab/udata-front/pull/26)
 

--- a/theme/js/locales/en.json
+++ b/theme/js/locales/en.json
@@ -114,5 +114,6 @@
   "See dataset linked to this schema": "See dataset linked to this schema",
   "About schemas": "About schemas",
   "Data schemas allow to describe data models : what are the fields, how is data represented, what are the possible values. Discover how schemas improve data quality and use cases on ": "Data schemas allow to describe data models : what are the fields, how is data represented, what are the possible values. Discover how schemas improve data quality and use cases on ",
-  "Available": "Available"
+  "Available": "Available",
+  "Unavailable": ""
 }

--- a/theme/js/locales/es.json
+++ b/theme/js/locales/es.json
@@ -114,5 +114,6 @@
   "See dataset linked to this schema": "See dataset linked to this schema",
   "About schemas": "About schemas",
   "Data schemas allow to describe data models : what are the fields, how is data represented, what are the possible values. Discover how schemas improve data quality and use cases on ": "Data schemas allow to describe data models : what are the fields, how is data represented, what are the possible values. Discover how schemas improve data quality and use cases on ",
-  "Available": "Available"
+  "Available": "Available",
+  "Unavailable": ""
 }

--- a/theme/js/locales/fr.json
+++ b/theme/js/locales/fr.json
@@ -114,5 +114,6 @@
   "See dataset linked to this schema": "Voir les jeux de données associés à ce schéma",
   "About schemas": "À propos des schémas",
   "Data schemas allow to describe data models : what are the fields, how is data represented, what are the possible values. Discover how schemas improve data quality and use cases on ": "Les schémas de données permettent de décrire des modèles de données : quels sont les différents champs, comment sont représentées les données, quelles sont les valeurs possibles. Découvrez comment les schémas améliorent la qualité des données et quels sont les cas d'usages possibles sur ",
-  "Available": "Disponible"
+  "Available": "Disponible",
+  "Unavailable": ""
 }

--- a/theme/less/components/borders.less
+++ b/theme/less/components/borders.less
@@ -103,6 +103,14 @@ You can change this behaviour by using the `filet-currentcolor` class that will 
     border-color: @orange-100;
 }
 
+.border-g200 {
+    border-color: var(--g200);
+}
+
+.border-g400 {
+    border-color: var(--g400);
+}
+
 each(@breakpoints, .(@bk, @_k, @_i) {
     @var: 'query-@{bk}';
 

--- a/theme/less/index.less
+++ b/theme/less/index.less
@@ -59,6 +59,7 @@
 @import "./specific/footer.less";
 @import "./specific/metadata.less";
 @import "./specific/metrics-bar.less";
+@import "./specific/oauth.less";
 @import "./specific/producer-summary.less";
 @import "./specific/resource-card.less";
 @import "./specific/reuse.less";

--- a/theme/less/specific/oauth.less
+++ b/theme/less/specific/oauth.less
@@ -1,0 +1,5 @@
+.client-logo {
+    max-height: 78px;
+    object-fit: contain;
+    object-position: left;
+}

--- a/udata_front/theme/gouvfr/templates/api/oauth_authorize.html
+++ b/udata_front/theme/gouvfr/templates/api/oauth_authorize.html
@@ -9,7 +9,7 @@
             <div class="fr-grid-row fr-grid-row--center">
                 <div class="fr-col-12 fr-col-md-8 fr-col-lg-6 bg-white">
                     <div class="fr-px-7v fr-py-5w border-bottom border-g200">
-                        <div class="fr-grid-row">
+                        <div class="fr-grid-row fr-grid-row--middle">
                             {% if grant.client.organization %}
                                 <div class="fr-mr-4w">
                                     <img

--- a/udata_front/theme/gouvfr/templates/api/oauth_authorize.html
+++ b/udata_front/theme/gouvfr/templates/api/oauth_authorize.html
@@ -1,62 +1,66 @@
-{% extends theme('layouts/center-panel.html') %}
-
+{% extends theme('base.html') %}
 {% set meta = {
     'title': _('External application authorization'),
 } %}
 
-
-{% block panel_content %}
-<div class="panel-body oauth-authorize">
-    <div class="row">
-        <div class="col-xs-12">
-            <img src="{{ grant.client.image(100) }}" class="pull-left app-logo" width="100" height="100" alt="">
-            <p class="lead prompt">
-            {{ _(
-                '%(app)s want to access your %(site)s account.',
-                app='<span class="app">%s</span>'|format(grant.client.name)|safe,
-                site='<span class="site">%s</span>'|format(config.SITE_TITLE)|safe
-            ) }}
-            </p>
-        </div>
-    </div>
-</div>
-<div class="panel-body oauth-authorize">
-    <div class="row">
-        <div class="col-xs-12">
-            <h4>{{ _('Details') }}</h4>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-xs-12">
-            <div class="scope-details">
-                <div class="scope-picto">
-                    <span class="fa fa-male fa-4x"></span>
-                </div>
-                <div class="scope-body">
-                    <h4>{{ _('Access your profile') }}</h4>
-                    <p>{{ _('Read your profile, the orgnization you belong to, your publications') }}</p>
+{% block content %}
+    <section class="fr-py-3w fr-py-md-9v bg-grey-50">
+        <div class="fr-container">
+            <div class="fr-grid-row fr-grid-row--center">
+                <div class="fr-col-12 fr-col-md-8 fr-col-lg-6 bg-white">
+                    <div class="fr-px-7v fr-py-5w border-bottom border-g200">
+                        <div class="fr-grid-row">
+                            {% if grant.client.organization %}
+                                <div class="fr-mr-4w">
+                                    <img
+                                        alt="{{ grant.client.organization.name|placeholder_alt(grant.client.organization.logo) }}"
+                                        src="{{ grant.client.organization.logo(120)|placeholder('organization') }}"
+                                    />
+                                </div>
+                            {% endif %}
+                            <div class="fr-col-4">
+                                <img src="{{ grant.client.image }}" alt="" class="fr-responsive-img">
+                            </div>
+                            <p class="fr-text--lead fr-mt-3w fr-mb-0">
+                                {{ _(
+                                '%(app)s want to access your %(site)s account.',
+                                app='<strong>%s</strong>'|format(grant.client.name)|safe,
+                                site='<strong>%s</strong>'|format(config.SITE_TITLE)|safe
+                            ) }}
+                            </p>
+                        </div>
+                    </div>
+                    <div class="fr-px-7v fr-py-5w">
+                        <div>
+                            <p class="fr-text--sm fr-mb-5v">{{ _('This site request the following rights:') }}</p>
+                            <dl>
+                                <dt class="f-bold">{{ _('Access your profile') }}</dt>
+                                <dd class="fr-text--sm fr-pb-3w fr-mb-5v border-bottom border-g400">{{ _('Read your profile, the orgnization you belong to, your publications') }}</dd>
+                                <dt class="f-bold">{{ _('Publish data') }}</dt>
+                                <dd class="fr-text--sm fr-pb-3w fr-mb-5w border-bottom border-g400">{{ _('Publish datasets, reuses, follow or unfollow') }}</dd>
+                            </dl>
+                        </div>
+                        <form class="fr-grid-row fr-grid-row--center" method="post">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                            <input type="hidden" name="scope" value="{{ (grant.scopes or ['default']) | join(' ') }}" />
+                            <button
+                                type="submit"
+                                name="decline"
+                                class="btn-secondary btn-secondary-grey-500 fr-mr-5w"
+                            >
+                                {{ _('Refuse') }}
+                            </button>
+                            <button
+                                type="submit"
+                                name="accept"
+                                class="btn-primary"
+                            >
+                                {{ _('Accept') }}
+                            </button>
+                        </form>
+                    </div>
                 </div>
             </div>
-            <div class="scope-details">
-                <div class="scope-picto">
-                    <span class="fa fa-file-o fa-4x"></span>
-                </div>
-                <div class="scope-body">
-                    <h4>{{ _('Publish data') }}</h4>
-                    <p>{{ _('Publish datasets, reuses, follow or unfollow') }}</p>
-                </div>
-            </div>
         </div>
-    </div>
-</div>
-<div class="panel-body">
-    <form class="form text-center" method="post">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-        <input type="hidden" name="scope" value="{{ (grant.scopes or ['default']) | join(' ') }}" />
-        <input type="submit" name="accept" value="{{ _('Accept') }}"
-            class="btn btn-success btn-lg" />
-        <input type="submit" name="decline" value="{{ _('Refuse') }}"
-            class="btn btn-danger btn-lg" />
-    </form>
-</div>
+    </section>
 {% endblock %}

--- a/udata_front/theme/gouvfr/templates/api/oauth_authorize.html
+++ b/udata_front/theme/gouvfr/templates/api/oauth_authorize.html
@@ -11,17 +11,20 @@
                     <div class="fr-px-7v fr-py-5w border-bottom border-g200">
                         <div class="fr-grid-row fr-grid-row--middle">
                             {% if grant.client.organization %}
-                                <div class="fr-mr-4w">
+                                <div class="fr-mr-4w fr-mb-3w">
                                     <img
                                         alt="{{ grant.client.organization.name|placeholder_alt(grant.client.organization.logo) }}"
                                         src="{{ grant.client.organization.logo(120)|placeholder('organization') }}"
+                                        class="client-logo"
                                     />
                                 </div>
                             {% endif %}
-                            <div class="fr-col-4">
-                                <img src="{{ grant.client.image }}" alt="" class="fr-responsive-img">
+                            {% if grant.client.image %}
+                            <div class="fr-col-4 fr-mb-3w">
+                                <img src="{{ grant.client.image }}" alt="" class="fr-responsive-img client-logo">
                             </div>
-                            <p class="fr-text--lead fr-mt-3w fr-mb-0">
+                            {% endif %}
+                            <p class="fr-text--lead fr-mb-0">
                                 {{ _(
                                 '%(app)s want to access your %(site)s account.',
                                 app='<strong>%s</strong>'|format(grant.client.name)|safe,

--- a/udata_front/theme/gouvfr/templates/api/oauth_error.html
+++ b/udata_front/theme/gouvfr/templates/api/oauth_error.html
@@ -2,19 +2,16 @@
 
 {% block content %}
 <section class="error">
-    <div class="container">
-
-        <div class="jumbotron">
-            <h1>{{ _('OAuth Authentication Error') }}</h1>
-            <p class="lead">{{ request.args.error }}</p>
-            <p class="text-center">
-                <a class="btn btn-primary btn-lg" role="button" href="{{ url_for('site.home') }}">
-                    <span class="fa fa-home"></span>
-                    {{ _('Home') }}
-                </a>
-            </p>
-        </div>
-
+    <div class="fr-container py-xl">
+        <h1 class="fr-h2">{{ _('OAuth Authentication Error') }}</h1>
+        {% if error %}
+        <p class="fr-text--lead">{{ error }}</p>
+        {% endif %}
+        <p class="text-center">
+            <a class="btn btn-primary btn-lg" role="button" href="{{ url_for('site.home') }}">
+                {{ _('Home') }}
+            </a>
+        </p>
     </div>
 </section>
 {% endblock %}

--- a/udata_front/theme/gouvfr/translations/gouvfr.pot
+++ b/udata_front/theme/gouvfr/translations/gouvfr.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: udata-front 1.1.2.dev0\n"
 "Report-Msgid-Bugs-To: data.gouv@data.gouv.fr\n"
-"POT-Creation-Date: 2021-11-12 14:38+0100\n"
-"PO-Revision-Date: 2021-11-12 14:38+0100\n"
+"POT-Creation-Date: 2021-11-12 14:40+0100\n"
+"PO-Revision-Date: 2021-11-12 14:40+0100\n"
 "Last-Translator: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
 "Language: en\n"
 "Language-Team: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
@@ -293,7 +293,7 @@ msgstr ""
 msgid "Main navigation menu"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/api/oauth_error.html:13
+#: udata_front/theme/gouvfr/templates/api/oauth_error.html:12
 #: udata_front/theme/gouvfr/templates/errors/base.html:18
 #: udata_front/theme/gouvfr/templates/home.html:4
 #: udata_front/theme/gouvfr/templates/macros/breadcrumb.html:16
@@ -547,7 +547,7 @@ msgstr ""
 msgid "Accept"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/api/oauth_error.html:8
+#: udata_front/theme/gouvfr/templates/api/oauth_error.html:6
 msgid "OAuth Authentication Error"
 msgstr ""
 

--- a/udata_front/theme/gouvfr/translations/gouvfr.pot
+++ b/udata_front/theme/gouvfr/translations/gouvfr.pot
@@ -514,36 +514,36 @@ msgstr ""
 msgid "External application authorization"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:25
+#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:28
 #, python-format
 msgid "%(app)s want to access your %(site)s account."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:35
+#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:38
 msgid "This site request the following rights:"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:37
+#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:40
 msgid "Access your profile"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:38
+#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:41
 msgid "Read your profile, the orgnization you belong to, your publications"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:39
+#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:42
 msgid "Publish data"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:40
+#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:43
 msgid "Publish datasets, reuses, follow or unfollow"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:51
+#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:54
 msgid "Refuse"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:58
+#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:61
 msgid "Accept"
 msgstr ""
 

--- a/udata_front/theme/gouvfr/translations/gouvfr.pot
+++ b/udata_front/theme/gouvfr/translations/gouvfr.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: udata-front 1.1.2.dev0\n"
 "Report-Msgid-Bugs-To: data.gouv@data.gouv.fr\n"
-"POT-Creation-Date: 2021-11-09 19:37+0100\n"
-"PO-Revision-Date: 2021-11-09 19:37+0100\n"
+"POT-Creation-Date: 2021-11-12 14:38+0100\n"
+"PO-Revision-Date: 2021-11-12 14:38+0100\n"
 "Last-Translator: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
 "Language: en\n"
 "Language-Team: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
@@ -510,41 +510,41 @@ msgstr ""
 msgid "Add a client"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:4
+#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:3
 msgid "External application authorization"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:14
+#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:25
 #, python-format
 msgid "%(app)s want to access your %(site)s account."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:26
-msgid "Details"
-msgstr ""
-
-#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:36
-msgid "Access your profile"
+#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:35
+msgid "This site request the following rights:"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:37
+msgid "Access your profile"
+msgstr ""
+
+#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:38
 msgid "Read your profile, the orgnization you belong to, your publications"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:45
+#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:39
 msgid "Publish data"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:46
+#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:40
 msgid "Publish datasets, reuses, follow or unfollow"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:56
-msgid "Accept"
+#: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:51
+msgid "Refuse"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/api/oauth_authorize.html:58
-msgid "Refuse"
+msgid "Accept"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/api/oauth_error.html:8

--- a/udata_front/views/gouvfr.py
+++ b/udata_front/views/gouvfr.py
@@ -132,10 +132,16 @@ def dataset_apis(ctx):
     return theme.render('dataset-apis.html', apis=dataset.extras.get(APIGOUVFR_EXTRAS_KEY))
 
 
-@template_hook('oauth_theme_content')
+@template_hook('oauth_authorize_theme_content')
 def oauth_theme_content(ctx):
     grant = ctx['grant']
     return theme.render('api/oauth_authorize.html', grant=grant)
+
+
+@template_hook('oauth_error_theme_content')
+def oauth_theme_content(ctx):
+    request = ctx['request']
+    return theme.render('api/oauth_error.html', error=request.args.get('error'))
 
 
 # TODO : better this, redirect is not the best. How to serve it instead ?!

--- a/udata_front/views/gouvfr.py
+++ b/udata_front/views/gouvfr.py
@@ -133,13 +133,13 @@ def dataset_apis(ctx):
 
 
 @template_hook('oauth_authorize_theme_content')
-def oauth_theme_content(ctx):
+def oauth_authorize_theme_content(ctx):
     grant = ctx['grant']
     return theme.render('api/oauth_authorize.html', grant=grant)
 
 
 @template_hook('oauth_error_theme_content')
-def oauth_theme_content(ctx):
+def oauth_error_theme_content(ctx):
     request = ctx['request']
     return theme.render('api/oauth_error.html', error=request.args.get('error'))
 


### PR DESCRIPTION
Close https://github.com/etalab/data.gouv.fr/issues/466
Based on https://www.figma.com/file/kfpGHDywdXEr0phdHfjTMc/Live%2FFixes?node-id=437%3A11198

<img width="719" alt="Capture d’écran 2021-11-04 à 15 32 53" src="https://user-images.githubusercontent.com/8336712/140333114-d09718bc-0d65-4e98-aa43-97cb349fb468.png">


Because of oauth client and organization image ratio, we might want to change the header.
See below for some examples.

<img width="1135" alt="Capture d’écran 2021-11-04 à 15 22 15" src="https://user-images.githubusercontent.com/8336712/140332401-2d4cf8de-c8e2-48a0-b256-2dd54526274e.png">
<img width="1140" alt="Capture d’écran 2021-11-04 à 15 22 37" src="https://user-images.githubusercontent.com/8336712/140332410-a654bf59-301b-4ab9-8758-620fadcc0b81.png">

