### PR TITLE
Fix gouvfr static path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Move template hook logic to udata and add oauth hooks [#29](https://github.com/etalab/udata-front/pull/29)
 - Add resources pagination dataset page and use DSFR pagination [#30](https://github.com/etalab/udata-front/pull/30)
 - Style oauth page [#34](https://github.com/etalab/udata-front/pull/34)
+- Fix gouvfr static path [#39](https://github.com/etalab/udata-front/pull/39)
 
 ## 1.1.1 (2021-10-22)
 

--- a/udata_front/views/gouvfr.py
+++ b/udata_front/views/gouvfr.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 
 blueprint = I18nBlueprint('gouvfr', __name__,
                           template_folder='../templates',
-                          static_folder='static',
+                          static_folder='../static',
                           static_url_path='/static/gouvfr')
 
 PAGE_CACHE_DURATION = 60 * 5  # in seconds


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/603

The link to the "local" static folder was wrong and thus the static files not correctly collected by `udata collect`.

This happened because we changed the folder structure (adding a `views` folder) since https://github.com/etalab/udata-gouvfr/blob/v2.6.2/udata_gouvfr/views.py.