### PR TITLE
Feat/update reuses style

### DIFF
--- a/theme/js/components/reuse/card.vue
+++ b/theme/js/components/reuse/card.vue
@@ -2,7 +2,7 @@
 Vue and simpler -->
 
 <template>
-  <article class="reuse-card text-align-center fr-text--sm fr-mb-0">
+  <article class="reuse-card text-align-center fr-text--sm fr-mb-0" :class="{'reuse-card--fluid': fluid}">
     <Placeholder
       class="reuse-image fr-mb-3v fr-responsive-img"
       alt=""
@@ -38,7 +38,11 @@ export default {
     },
     private: {
       type: Boolean,
-      default: false
+      default: false,
+    },
+    fluid: {
+      type: Boolean,
+      default: false,
     }
   },
   components: {

--- a/theme/js/components/reuse/card.vue
+++ b/theme/js/components/reuse/card.vue
@@ -2,22 +2,22 @@
 Vue and simpler -->
 
 <template>
-  <article class="reuse-card">
+  <article class="reuse-card text-align-center fr-text--sm fr-mb-0">
     <Placeholder
-      class="reuse-image mb-sm"
-      :alt="title"
-      backgroundImage
+      class="reuse-image fr-mb-3v fr-responsive-img"
+      alt=""
       :src="image_url"
       type="reuse"
     />
-    <div class="reuse-info">
-      <div class="reuse-info-type fs-xs">
-        {{ type_label }}
-      </div>
-      <div class="reuse-info-amount fs-xs text-grey-300 mb-xs"></div>
-      <div class="reuse-info-title h4">
-        {{ title }}
-      </div>
+    <div>
+      {{ type_label }}
+    </div>
+    <div class="text-grey-300">
+      {{ $tc('X datasets', datasets) }}
+    </div>
+    <div>
+      {{ title }}
+      <span class="badge grey-300 fr-ml-1w" v-if="private">{{ $t('Private') }}</span>
     </div>
   </article>
 </template>
@@ -27,18 +27,27 @@ import Placeholder from "../utils/placeholder";
 import icon from "svg/actions/star.svg";
 
 export default {
-  created() {
-    this.icon = icon;
-  },
   props: {
     title: String,
     image_url: String,
     type_label: String,
     metrics: Object,
-    datasets: Number,
+    datasets: {
+      type: Number,
+      default: 0,
+    },
+    private: {
+      type: Boolean,
+      default: false
+    }
   },
   components: {
     Placeholder,
+  },
+  data() {
+   return {
+     icon
+   }
   },
 };
 </script>

--- a/theme/js/components/search/suggest-results.vue
+++ b/theme/js/components/search/suggest-results.vue
@@ -12,8 +12,8 @@ Used by the suggest feature to display typeahead-style results when you type you
 -->
 
 <template>
-  <div class="row p-md results">
-    <div class="p-md col col-md-12">
+  <div class="row fr-p-2w results">
+    <div class="fr-p-2w col col-md-12">
       <a
         class="unstyled row-inline justify-between see-all"
         :href="datasetUrl"
@@ -24,7 +24,7 @@ Used by the suggest feature to display typeahead-style results when you type you
         </h2>
         <span v-html="arrow" />
       </a>
-      <p class="text-grey-300 m-0">
+      <p class="text-grey-300 fr-m-0">
         {{
           $t(
             "Datasets are collections of data, i.e. structured information, easily readable by a machine."
@@ -40,7 +40,7 @@ Used by the suggest feature to display typeahead-style results when you type you
           :queryString="queryString"
           :link="datasetUrl"
         />
-        <div class="my-md cards-container reuse-cards" v-else>
+        <div class="fr-my-2w cards-container" v-else>
           <ul>
             <li v-for="dataset in results.datasets">
               <a :href="dataset.page" :title="dataset.title" class="unstyled">
@@ -48,13 +48,13 @@ Used by the suggest feature to display typeahead-style results when you type you
               </a>
             </li>
           </ul>
-          <a class="nav-link pt-md" :href="datasetUrl">{{
+          <a class="nav-link fr-pt-2w" :href="datasetUrl">{{
             $t("Search in datasets")
           }}</a>
         </div>
       </transition>
     </div>
-    <div class="p-md col col-md-12">
+    <div class="fr-p-2w col col-md-12">
       <a
         class="unstyled row-inline justify-between see-all"
         :href="reuseUrl"
@@ -65,7 +65,7 @@ Used by the suggest feature to display typeahead-style results when you type you
         </h2>
         <span v-html="arrow" />
       </a>
-      <p class="text-grey-300 m-0">
+      <p class="text-grey-300 fr-m-0">
         {{
           $t(
             "Reuses refer to the use of data for an other purpose than the one they were produced for."
@@ -73,7 +73,7 @@ Used by the suggest feature to display typeahead-style results when you type you
         }}
       </p>
       <transition mode="out-in">
-        <reuse-loader class="my-md" v-if="loading" />
+        <reuse-loader class="fr-my-2w" v-if="loading" />
         <Empty
           v-else-if="!results.reuses.length > 0"
           :cta="$t('See the reuses')"
@@ -81,15 +81,15 @@ Used by the suggest feature to display typeahead-style results when you type you
           :queryString="queryString"
           :link="reuseUrl"
         />
-        <div class="my-md cards-container" v-else>
+        <div class="fr-my-2w cards-container" v-else>
           <ul class="row">
-            <li v-for="reuse in results.reuses" class="col text-align-center">
+            <li v-for="reuse in results.reuses" class="col-6">
               <a :href="reuse.page" :title="reuse.title" class="unstyled">
-                <Reuse v-bind="reuse" />
+                <Reuse v-bind="reuse" :fluid="true" />
               </a>
             </li>
           </ul>
-          <a class="nav-link pt-md" :href="reuseUrl">{{
+          <a class="nav-link fr-pt-2w" :href="reuseUrl">{{
             $t("Search reuses")
           }}</a>
         </div>

--- a/theme/js/locales/en.json
+++ b/theme/js/locales/en.json
@@ -117,5 +117,7 @@
   "Available": "Available",
   "Unavailable": "Unavailable",
   "Come try out our": "Come try out our {dataset_search}.",
-  "new dataset search": "new dataset search"
+  "new dataset search": "new dataset search",
+  "X datasets": "0 datasets | 1 dataset | {n} datasets",
+  "Private": "Private"
 }

--- a/theme/js/locales/es.json
+++ b/theme/js/locales/es.json
@@ -117,5 +117,7 @@
   "Available": "Available",
   "Unavailable": "Unavailable",
   "Come try out our": "Come try out our {dataset_search}.",
-  "new dataset search": "new dataset search"
+  "new dataset search": "new dataset search",
+  "X datasets": "",
+  "Private": ""
 }

--- a/theme/js/locales/fr.json
+++ b/theme/js/locales/fr.json
@@ -117,5 +117,7 @@
   "Available": "Disponible",
   "Unavailable": "Indisponible",
   "Come try out our": "Venez tester notre {dataset_search}.",
-  "new dataset search": "nouvelle recherche de jeux de données"
+  "new dataset search": "nouvelle recherche de jeux de données",
+  "X datasets": "",
+  "Private": ""
 }

--- a/theme/less/components/buttons.less
+++ b/theme/less/components/buttons.less
@@ -176,18 +176,6 @@ There are `.fr-btn--icon-left` and `fr-btn--icon-right` to add spacing around th
     &.active {
         background-color: lighten(@blue-400, 10%);
     }
-
-    each(@colors, {
-        &.btn-primary-@{value} {
-            @contrast: 'contrast-@{value}';
-            background-color: @@value;
-            color: @@contrast;
-
-            &:active, &:hover, &.active {
-                background-color: lighten(@@value, 10%);
-            }
-        }
-    });
 }
 
 .btn-secondary {

--- a/theme/less/content/colors.less
+++ b/theme/less/content/colors.less
@@ -95,7 +95,7 @@ Similar to the contextual text color classes, easily set the background of an el
 @grey-50: #f9f9f9;
 @grey-100: #e5e5e5;
 @grey-200: #d7d7d7;
-@grey-300: #7c7c7c;
+@grey-300: var(--g600);
 @grey-380: #2d2d2d;
 @grey-400: #232323;
 @grey-500: #161616;

--- a/theme/less/layout/grid.less
+++ b/theme/less/layout/grid.less
@@ -204,6 +204,10 @@ in which case you'll have one column on each side and the main content will span
     overflow: visible !important;
 }
 
+.overflow-x-scroll {
+    overflow-x: scroll !important;
+}
+
 .block {
     display: block;
 }

--- a/theme/less/specific/reuse.less
+++ b/theme/less/specific/reuse.less
@@ -1,4 +1,4 @@
-//Home section
+// Home section
 .reuse {
     .tab-content {
         min-width: @breakpoint-lg;
@@ -21,16 +21,12 @@
     }
 }
 
-//Generic reuse cards
+// Generic reuse cards
 .reuse-card {
     .reuse-image {
         border-radius: @spacing-md;
-        max-width: 100%;
-        width: 100%;
-        min-height: 320px;
-
-        background-repeat: no-repeat;
-        background-size: cover;
-        background-position: center center;
+        height: 480px;
+        object-fit: cover;
+        object-position: center center;
     }
 }

--- a/theme/less/specific/reuse.less
+++ b/theme/less/specific/reuse.less
@@ -5,28 +5,17 @@
     }
 }
 
-.reuse-cards {
-    @media @query-xl {
-        overflow-x: scroll;
-
-        .row {
-            flex-wrap: nowrap;
-
-            //Prevent reuse cards from being too small
-            > div,
-            > li {
-                min-width: 250px;
-            }
-        }
-    }
-}
-
 // Generic reuse cards
 .reuse-card {
+    width: 285px;
     .reuse-image {
         border-radius: @spacing-md;
         height: 480px;
         object-fit: cover;
         object-position: center center;
+    }
+
+    &.reuse-card--fluid {
+        width: 100%;
     }
 }

--- a/udata_front/theme/gouvfr/templates/dataset/display.html
+++ b/udata_front/theme/gouvfr/templates/dataset/display.html
@@ -1,6 +1,7 @@
 {% extends theme('layouts/1-column.html') %}
 {% from theme('macros/follow.html') import follow_btn with context %}
 {% from theme('macros/integrate.html') import integrate_btn with context %}
+{% from theme('macros/paginator.html') import paginator with context %}
 {% from theme('macros/breadcrumb.html') import breadcrumb with context %}
 
 ## FIXME: remove inspire:indentifier robots condition when geo.data.gouv.fr is shutdown
@@ -289,7 +290,7 @@
                     </li>
                     <li>
                         <a class="fr-summary__link" href="#community-reuses">
-                            {{ _('Reuses') }}  <sup class="sup">{{ reuses|length }}</sup>
+                            {{ _('Reuses') }}  <sup class="sup">{{ total_reuses }}</sup>
                         </a>
                     </li>
                     <li>
@@ -374,7 +375,7 @@
         {% endif %}
 
         {% block reuses_section %}
-        <h2 id="community-reuses" class="fr-h2">{{ _('Reuses') }} <sup>{{ reuses|length }}</sup></h2>
+        <h2 id="community-reuses" class="fr-h2">{{ _('Reuses') }} <sup>{{ total_reuses }}</sup></h2>
         <div class="row fr-mb-3w">
             <div class="col-6 col-md-12 text-grey-300">
                 {% trans %}You reused these data and published an article, a computer graphics, or an application?
@@ -382,14 +383,15 @@
                 Reference your work in just a few clicks and increase your visibility.{% endtrans %}
             </div>
         </div>
-        <div class="row mt-xl fr-pt-2w fr-pt-md-0 overflow-x-scroll">
+        <div class="fr-mt-9v fr-pt-2w fr-pt-md-0 fr-grid-row fr-grid-row--gutters no-wrap fr-mb-2w overflow-x-scroll">
             {% for reuse in reuses %}
             {% set features = ['preview'] %}
-            <div class="col-3 col-md-6">
+            <div class="fr-col">
                 {% include theme('reuse/card.html') %}
             </div>
             {% endfor %}
         </div>
+        {{ paginator(reuses, arg_name='reuses_page', url='#community-reuses') }}
         {% if not read_only_mode %}
         <div class="row">
             <div class="col-12">

--- a/udata_front/theme/gouvfr/templates/dataset/display.html
+++ b/udata_front/theme/gouvfr/templates/dataset/display.html
@@ -382,7 +382,7 @@
                 Reference your work in just a few clicks and increase your visibility.{% endtrans %}
             </div>
         </div>
-        <div class="row mt-xl fr-pt-2w fr-pt-md-0 reuse-cards">
+        <div class="row mt-xl fr-pt-2w fr-pt-md-0 overflow-x-scroll">
             {% for reuse in reuses %}
             {% set features = ['preview'] %}
             <div class="col-3 col-md-6">

--- a/udata_front/theme/gouvfr/templates/dataset/display.html
+++ b/udata_front/theme/gouvfr/templates/dataset/display.html
@@ -378,10 +378,10 @@
         <h2 id="community-reuses" class="fr-h2">{{ _('Reuses') }} <sup>{{ total_reuses }}</sup></h2>
         <p class="fr-my-0">{{ _('Explore the reuses of this dataset.') }}</p>
         <p class="fr-mt-0 fr-mb-3w">{{ _('Did you use this data ? Reference your work and increase your visibility.') }}</p>
-        <div class="fr-pt-2w fr-pt-md-0 fr-grid-row fr-grid-row--gutters no-wrap fr-mb-2w overflow-x-scroll">
+        <div class="fr-pt-2w fr-pt-md-0 fr-grid-row no-wrap fr-mb-2w overflow-x-scroll">
             {% for reuse in reuses %}
             {% set features = ['preview'] %}
-            <div class="fr-col">
+            <div class="fr-p-3v">
                 {% include theme('reuse/card.html') %}
             </div>
             {% endfor %}

--- a/udata_front/theme/gouvfr/templates/dataset/display.html
+++ b/udata_front/theme/gouvfr/templates/dataset/display.html
@@ -376,14 +376,9 @@
 
         {% block reuses_section %}
         <h2 id="community-reuses" class="fr-h2">{{ _('Reuses') }} <sup>{{ total_reuses }}</sup></h2>
-        <div class="row fr-mb-3w">
-            <div class="col-6 col-md-12 text-grey-300">
-                {% trans %}You reused these data and published an article, a computer graphics, or an application?
-                It's time to let you know!
-                Reference your work in just a few clicks and increase your visibility.{% endtrans %}
-            </div>
-        </div>
-        <div class="fr-mt-9v fr-pt-2w fr-pt-md-0 fr-grid-row fr-grid-row--gutters no-wrap fr-mb-2w overflow-x-scroll">
+        <p class="fr-my-0">{{ _('Explore the reuses of this dataset.') }}</p>
+        <p class="fr-mt-0 fr-mb-3w">{{ _('Did you use this data ? Reference your work and increase your visibility.') }}</p>
+        <div class="fr-pt-2w fr-pt-md-0 fr-grid-row fr-grid-row--gutters no-wrap fr-mb-2w overflow-x-scroll">
             {% for reuse in reuses %}
             {% set features = ['preview'] %}
             <div class="fr-col">

--- a/udata_front/theme/gouvfr/templates/home.html
+++ b/udata_front/theme/gouvfr/templates/home.html
@@ -149,13 +149,13 @@
             </div>
         </div>
     </div>
-    <div class="hagrid overflow-x-scroll">
+    <div class="hagrid">
         {% for tab_id, label, reuses, kwargs in reuses_tabs  %}
-        <div class="tab-content  {% if loop.first %}active{% endif %}" id="{{tab_id}}">
-            <div class="row pt-xl pt-md-md">
+        <div class="tab-content {% if loop.first %}active{% endif %}" id="{{tab_id}}">
+            <div class="row pt-xl pt-md-md overflow-x-scroll no-wrap">
                 {% for reuse in reuses %}
                 {% set features = ['preview'] %}
-                <div class="col mb-md text-align-center">
+                <div class="col mb-md">
                     {% include theme('reuse/card.html') %}
                 </div>
                 {% endfor %}

--- a/udata_front/theme/gouvfr/templates/home.html
+++ b/udata_front/theme/gouvfr/templates/home.html
@@ -149,13 +149,13 @@
             </div>
         </div>
     </div>
-    <div class="hagrid reuse-cards">
+    <div class="hagrid overflow-x-scroll">
         {% for tab_id, label, reuses, kwargs in reuses_tabs  %}
         <div class="tab-content  {% if loop.first %}active{% endif %}" id="{{tab_id}}">
             <div class="row pt-xl pt-md-md">
                 {% for reuse in reuses %}
                 {% set features = ['preview'] %}
-                <div class="col-3 col-md-7 mb-md text-align-center">
+                <div class="col mb-md text-align-center">
                     {% include theme('reuse/card.html') %}
                 </div>
                 {% endfor %}

--- a/udata_front/theme/gouvfr/templates/organization/display.html
+++ b/udata_front/theme/gouvfr/templates/organization/display.html
@@ -94,7 +94,7 @@
     <h2>{{ _('Reuses') }}<sup>{{ total_reuses }}</sup></h2>
     <ul class="fr-grid-row fr-grid-row--gutters no-wrap fr-mb-2w overflow-x-scroll">
         {% for reuse in reuses %}
-        <li class="fr-col text-align-center">
+        <li class="fr-col">
             {% include theme('reuse/card.html') %}
         </li>
         {% endfor %}

--- a/udata_front/theme/gouvfr/templates/organization/display.html
+++ b/udata_front/theme/gouvfr/templates/organization/display.html
@@ -92,15 +92,15 @@
 {% if reuses and reuses|length > 0 %}
 <section id="organization-reuses" class="fr-py-9v container">
     <h2>{{ _('Reuses') }}<sup>{{ total_reuses }}</sup></h2>
-    <ul class="row">
-            {% for reuse in reuses %}
-            <li class="col-3 col-lg-6 col-sm-12 my-sm-sm text-align-center">
-                <a href="{{ url_for('reuses.show', reuse=reuse) }}"
-                    title="{{ reuse.title }}">{% include theme('reuse/card.html') %}
-                </a>
-            </li>
-            {% endfor %}
-        </ul>
+    <ul class="row fr-mb-2w">
+        {% for reuse in reuses %}
+        <li class="col-3 col-lg-6 col-sm-12 my-sm-sm text-align-center">
+            <a href="{{ url_for('reuses.show', reuse=reuse) }}"
+                title="{{ reuse.title }}">{% include theme('reuse/card.html') %}
+            </a>
+        </li>
+        {% endfor %}
+    </ul>
     {{ paginator(reuses, arg_name='reuses_page', url='#organization-reuses') }}
 </section>
 {% endif %}

--- a/udata_front/theme/gouvfr/templates/organization/display.html
+++ b/udata_front/theme/gouvfr/templates/organization/display.html
@@ -92,9 +92,9 @@
 {% if reuses and reuses|length > 0 %}
 <section id="organization-reuses" class="fr-py-9v container">
     <h2>{{ _('Reuses') }}<sup>{{ total_reuses }}</sup></h2>
-    <ul class="fr-grid-row fr-grid-row--gutters no-wrap fr-mb-2w overflow-x-scroll">
+    <ul class="fr-grid-row no-wrap fr-mb-2w overflow-x-scroll">
         {% for reuse in reuses %}
-        <li class="fr-col">
+        <li class="fr-p-3v">
             {% include theme('reuse/card.html') %}
         </li>
         {% endfor %}

--- a/udata_front/theme/gouvfr/templates/organization/display.html
+++ b/udata_front/theme/gouvfr/templates/organization/display.html
@@ -92,12 +92,10 @@
 {% if reuses and reuses|length > 0 %}
 <section id="organization-reuses" class="fr-py-9v container">
     <h2>{{ _('Reuses') }}<sup>{{ total_reuses }}</sup></h2>
-    <ul class="row fr-mb-2w">
+    <ul class="fr-grid-row fr-grid-row--gutters no-wrap fr-mb-2w overflow-x-scroll">
         {% for reuse in reuses %}
-        <li class="col-3 col-lg-6 col-sm-12 my-sm-sm text-align-center">
-            <a href="{{ url_for('reuses.show', reuse=reuse) }}"
-                title="{{ reuse.title }}">{% include theme('reuse/card.html') %}
-            </a>
+        <li class="fr-col text-align-center">
+            {% include theme('reuse/card.html') %}
         </li>
         {% endfor %}
     </ul>

--- a/udata_front/theme/gouvfr/templates/reuse/card.html
+++ b/udata_front/theme/gouvfr/templates/reuse/card.html
@@ -18,7 +18,7 @@
         <div class="text-grey-300">
             {{ reuse.datasets|length or 0 }} {{ _('datasets') }}
         </div>
-        <div class="fr-grid-row">
+        <div>
             {{ reuse.title }}
             {% if reuse.private %}<span class="badge grey-300 fr-ml-1w">{{ _('Private') }}</span>{% endif %}
         </div>

--- a/udata_front/theme/gouvfr/templates/reuse/card.html
+++ b/udata_front/theme/gouvfr/templates/reuse/card.html
@@ -1,31 +1,26 @@
 {% cache cache_duration, 'reuse-card', reuse.id|string, g.lang_code %}
 
-{# TODO : what was "preview" used for ? #}
-<a class="unstyled w-100 block" href="{{ url_for('reuses.show', reuse=reuse, _external=True) }}" title="{{ reuse.title }}">
-    <article class="reuse-card text-align-center px-sm">
-        <div class="reuse-image mb-sm"
-            style="background-image: url('{{ reuse.image|placeholder('reuse', external=True) }}')">
+<a
+    class="unstyled w-100 block"
+    href="{{ url_for('reuses.show', reuse=reuse, _external=True) }}"
+    title="{{ reuse.title }}"
+>
+    <article class="reuse-card text-align-center fr-text--sm fr-mb-0">
+        <img
+            class="reuse-image fr-mb-3v fr-responsive-img"
+            src="{{ reuse.image|placeholder('reuse', external=True) }}"
+            loading="lazy"
+            alt=""
+        />
+        <div>
+            {{ reuse.type_label }}
         </div>
-        <div class="reuse-info">
-            <div class="row-inline justify-between text-align-left">
-                <div>
-                    <span class="reuse-info-type fs-xs">
-                        {{ reuse.type_label }}
-                    </span>
-                    <div class="reuse-info-amount fs-xs text-grey-300 mb-xs">
-                        {{ reuse.datasets|length or 0 }} {{ _('datasets') }}
-                    </div>
-                </div>
-                <div class="relative">
-                    <span class="text-orange-100">{% include theme('svg/actions/star.svg') %}</span>
-                    <span class="badge orange-100 ml-xxs py-xxxs px-xs">{{ reuse.metrics.followers or 0 }}</span>
-                    <span class="visually-hidden">{{ _('favourites') }}</span>
-                </div>
-            </div>
-            <div class="reuse-info-title h4">
-                {{ reuse.title }}
-                {% if reuse.private %}<span class="badge grey-300 ml-xs">{{ _('Private') }}</span>{% endif %}
-            </div>
+        <div class="text-grey-300">
+            {{ reuse.datasets|length or 0 }} {{ _('datasets') }}
+        </div>
+        <div class="fr-grid-row">
+            {{ reuse.title }}
+            {% if reuse.private %}<span class="badge grey-300 fr-ml-1w">{{ _('Private') }}</span>{% endif %}
         </div>
     </article>
 </a>

--- a/udata_front/theme/gouvfr/templates/reuse/card.html
+++ b/udata_front/theme/gouvfr/templates/reuse/card.html
@@ -1,11 +1,11 @@
 {% cache cache_duration, 'reuse-card', reuse.id|string, g.lang_code %}
-
+{% set card_fluid = card_fluid or False %}
 <a
     class="unstyled w-100 block"
     href="{{ url_for('reuses.show', reuse=reuse, _external=True) }}"
     title="{{ reuse.title }}"
 >
-    <article class="reuse-card text-align-center fr-text--sm fr-mb-0">
+    <article class="reuse-card {% if card_fluid %}reuse-card--fluid{% endif %} text-align-center fr-text--sm fr-mb-0">
         <img
             class="reuse-image fr-mb-3v fr-responsive-img"
             src="{{ reuse.image|placeholder('reuse', external=True) }}"

--- a/udata_front/theme/gouvfr/templates/reuse/display.html
+++ b/udata_front/theme/gouvfr/templates/reuse/display.html
@@ -248,10 +248,10 @@
     <section class="container fr-py-7w">
         <h2 id="more-reuses" class="fr-h2">{{ _('More reuses') }}</h2>
         <p>{{ _('Discover more reuses.') }}</p>
-        <ul class="fr-grid-row fr-grid-row--gutters no-wrap overflow-x-scroll">
+        <ul class="fr-grid-row no-wrap overflow-x-scroll">
             {% for reuse in related_reuses %}
             {% set features = ['preview'] %}
-            <li class="fr-col">
+            <li class="fr-p-3v">
                 {% include theme('reuse/card.html') %}
             </li>
             {% endfor %}

--- a/udata_front/theme/gouvfr/templates/reuse/display.html
+++ b/udata_front/theme/gouvfr/templates/reuse/display.html
@@ -245,13 +245,13 @@
             </discussion-threads>
         </div>
     </section>
-    <section class="reuse-cards container fr-py-7w">
+    <section class="container fr-py-7w">
         <h2 id="more-reuses" class="fr-h2">{{ _('More reuses') }}</h2>
         <p>{{ _('Discover more reuses.') }}</p>
-        <ul class="fr-grid-row fr-grid-row--gutters no-wrap">
+        <ul class="fr-grid-row fr-grid-row--gutters no-wrap overflow-x-scroll">
             {% for reuse in related_reuses %}
             {% set features = ['preview'] %}
-            <li class="fr-col-12 fr-col-sm-6 fr-col-md-4 fr-col-lg-3">
+            <li class="fr-col">
                 {% include theme('reuse/card.html') %}
             </li>
             {% endfor %}

--- a/udata_front/theme/gouvfr/templates/reuse/display.html
+++ b/udata_front/theme/gouvfr/templates/reuse/display.html
@@ -245,12 +245,13 @@
             </discussion-threads>
         </div>
     </section>
-    <section class="reuse-xsell reuse-cards container py-hg">
+    <section class="reuse-cards container fr-py-7w">
         <h2 id="more-reuses" class="fr-h2">{{ _('More reuses') }}</h2>
-        <ul class="row">
+        <p>{{ _('Discover more reuses.') }}</p>
+        <ul class="fr-grid-row fr-grid-row--gutters no-wrap">
             {% for reuse in related_reuses %}
             {% set features = ['preview'] %}
-            <li class="col-3 col-md-6">
+            <li class="fr-col-12 fr-col-sm-6 fr-col-md-4 fr-col-lg-3">
                 {% include theme('reuse/card.html') %}
             </li>
             {% endfor %}

--- a/udata_front/theme/gouvfr/templates/reuse/list.html
+++ b/udata_front/theme/gouvfr/templates/reuse/list.html
@@ -57,13 +57,18 @@
         </ul>
     </div>
     <ul class="search-results row mt-lg-md">
+        {% with card_fluid=True %}
         {% for reuse in reuses %}
         <li class="col-3 col-lg-6 col-sm-12 my-sm-sm text-align-center">
-            <a href="{{ url_for('reuses.show', reuse=reuse) }}"
-                title="{{ reuse.title }}">{% include theme('reuse/card.html') %}
+            <a
+                href="{{ url_for('reuses.show', reuse=reuse) }}"
+                title="{{ reuse.title }}"
+            >
+                {% include theme('reuse/card.html') %}
             </a>
         </li>
         {% endfor %}
+        {% endwith %}
     </ul>
     {{ paginator(reuses) }}
 </section>

--- a/udata_front/theme/gouvfr/translations/gouvfr.pot
+++ b/udata_front/theme/gouvfr/translations/gouvfr.pot
@@ -6,10 +6,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: udata-front 1.1.2.dev0\n"
+"Project-Id-Version: udata-front 1.1.3.dev0\n"
 "Report-Msgid-Bugs-To: data.gouv@data.gouv.fr\n"
-"POT-Creation-Date: 2021-11-12 14:40+0100\n"
-"PO-Revision-Date: 2021-11-12 14:40+0100\n"
+"POT-Creation-Date: 2021-12-06 14:52+0100\n"
+"PO-Revision-Date: 2021-12-06 14:52+0100\n"
 "Last-Translator: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
 "Language: en\n"
 "Language-Team: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
@@ -24,15 +24,15 @@ msgid "Data"
 msgstr ""
 
 #: udata_front/theme/gouvfr/__init__.py:47
-#: udata_front/theme/gouvfr/templates/dataset/display.html:293
-#: udata_front/theme/gouvfr/templates/dataset/display.html:378
+#: udata_front/theme/gouvfr/templates/dataset/display.html:292
+#: udata_front/theme/gouvfr/templates/dataset/display.html:377
 #: udata_front/theme/gouvfr/templates/hetic/page2.html:42
 #: udata_front/theme/gouvfr/templates/home.html:61
-#: udata_front/theme/gouvfr/templates/organization/display.html:62
-#: udata_front/theme/gouvfr/templates/organization/display.html:106
+#: udata_front/theme/gouvfr/templates/organization/display.html:56
+#: udata_front/theme/gouvfr/templates/organization/display.html:94
 #: udata_front/theme/gouvfr/templates/page.html:35
 #: udata_front/theme/gouvfr/templates/post/display.html:75
-#: udata_front/theme/gouvfr/templates/reuse/display.html:30
+#: udata_front/theme/gouvfr/templates/reuse/display.html:29
 #: udata_front/theme/gouvfr/templates/reuse/list.html:5
 #: udata_front/theme/gouvfr/templates/reuse/list.html:15
 #: udata_front/theme/gouvfr/templates/reuse/list.html:45
@@ -46,7 +46,7 @@ msgstr ""
 
 #: udata_front/theme/gouvfr/__init__.py:48
 #: udata_front/theme/gouvfr/templates/home.html:63
-#: udata_front/theme/gouvfr/templates/organization/display.html:19
+#: udata_front/theme/gouvfr/templates/organization/display.html:20
 #: udata_front/theme/gouvfr/templates/organization/list.html:7
 #: udata_front/theme/gouvfr/templates/organization/list.html:17
 #: udata_front/theme/gouvfr/templates/organization/list.html:35
@@ -124,7 +124,7 @@ msgid "Download from "
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/api/card.html:14
-#: udata_front/theme/gouvfr/templates/dataset/display.html:125
+#: udata_front/theme/gouvfr/templates/dataset/display.html:124
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:177
 msgid "Producer"
 msgstr ""
@@ -142,9 +142,9 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:255
+#: udata_front/theme/gouvfr/templates/dataset/display.html:254
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:206
-#: udata_front/theme/gouvfr/templates/reuse/display.html:167
+#: udata_front/theme/gouvfr/templates/reuse/display.html:166
 msgid "Embed"
 msgstr ""
 
@@ -165,7 +165,7 @@ msgstr ""
 msgid "Territory"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:196
+#: udata_front/theme/gouvfr/templates/dataset/display.html:195
 #: udata_front/theme/gouvfr/templates/dataset/search-result.html:46
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:232
 msgid "Frequency"
@@ -324,15 +324,15 @@ msgstr ""
 msgid "All news"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:33
+#: udata_front/theme/gouvfr/templates/dataset/display.html:32
 #: udata_front/theme/gouvfr/templates/dataset/explore.html:7
 #: udata_front/theme/gouvfr/templates/dataset/followers.html:4
 #: udata_front/theme/gouvfr/templates/dataset/list.html:17
 #: udata_front/theme/gouvfr/templates/dataset/list.html:36
 #: udata_front/theme/gouvfr/templates/home.html:59
 #: udata_front/theme/gouvfr/templates/home.html:99
-#: udata_front/theme/gouvfr/templates/organization/display.html:55
-#: udata_front/theme/gouvfr/templates/organization/display.html:86
+#: udata_front/theme/gouvfr/templates/organization/display.html:49
+#: udata_front/theme/gouvfr/templates/organization/display.html:83
 #: udata_front/theme/gouvfr/templates/page.html:20
 #: udata_front/theme/gouvfr/templates/post/display.html:60
 #: udata_front/theme/gouvfr/templates/site/dashboard.html:20
@@ -343,8 +343,8 @@ msgstr ""
 msgid "Datasets"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:282
-#: udata_front/theme/gouvfr/templates/dataset/display.html:316
+#: udata_front/theme/gouvfr/templates/dataset/display.html:281
+#: udata_front/theme/gouvfr/templates/dataset/display.html:315
 #: udata_front/theme/gouvfr/templates/home.html:60
 #: udata_front/theme/gouvfr/templates/site/dashboard.html:21
 msgid "Resources"
@@ -359,12 +359,12 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:298
-#: udata_front/theme/gouvfr/templates/dataset/display.html:406
+#: udata_front/theme/gouvfr/templates/dataset/display.html:297
+#: udata_front/theme/gouvfr/templates/dataset/display.html:405
 #: udata_front/theme/gouvfr/templates/home.html:64
 #: udata_front/theme/gouvfr/templates/post/display.html:137
-#: udata_front/theme/gouvfr/templates/reuse/display.html:199
-#: udata_front/theme/gouvfr/templates/reuse/display.html:237
+#: udata_front/theme/gouvfr/templates/reuse/display.html:198
+#: udata_front/theme/gouvfr/templates/reuse/display.html:236
 #: udata_front/theme/gouvfr/templates/site/dashboard.html:25
 msgid "Discussions"
 msgstr ""
@@ -422,11 +422,11 @@ msgstr ""
 msgid "metrics"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:140
-#: udata_front/theme/gouvfr/templates/organization/display.html:158
+#: udata_front/theme/gouvfr/templates/dataset/display.html:139
+#: udata_front/theme/gouvfr/templates/organization/display.html:141
 #: udata_front/theme/gouvfr/templates/page.html:50
 #: udata_front/theme/gouvfr/templates/post/display.html:91
-#: udata_front/theme/gouvfr/templates/reuse/display.html:101
+#: udata_front/theme/gouvfr/templates/reuse/display.html:100
 msgid "Actions"
 msgstr ""
 
@@ -556,9 +556,9 @@ msgid "Due to security reasons, the creation of new content is currently disable
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/add-reuse-card.html:5
-#: udata_front/theme/gouvfr/templates/dataset/display.html:246
-#: udata_front/theme/gouvfr/templates/dataset/display.html:399
-#: udata_front/theme/gouvfr/templates/reuse/display.html:158
+#: udata_front/theme/gouvfr/templates/dataset/display.html:245
+#: udata_front/theme/gouvfr/templates/dataset/display.html:398
+#: udata_front/theme/gouvfr/templates/reuse/display.html:157
 msgid "Add a reuse"
 msgstr ""
 
@@ -576,50 +576,50 @@ msgstr ""
 msgid "reuses"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:12
+#: udata_front/theme/gouvfr/templates/dataset/display.html:11
 msgid "dataset"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:18
-#: udata_front/theme/gouvfr/templates/reuse/display.html:19
+#: udata_front/theme/gouvfr/templates/dataset/display.html:17
+#: udata_front/theme/gouvfr/templates/reuse/display.html:18
 #, python-format
 msgid "Explore with %(certifier)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:50
+#: udata_front/theme/gouvfr/templates/dataset/display.html:49
 msgid "This dataset is private and will not be visible by other users"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:50
+#: udata_front/theme/gouvfr/templates/dataset/display.html:49
 #: udata_front/theme/gouvfr/templates/dataset/search-result.html:28
-#: udata_front/theme/gouvfr/templates/reuse/card.html:27
-#: udata_front/theme/gouvfr/templates/reuse/display.html:44
+#: udata_front/theme/gouvfr/templates/reuse/card.html:23
+#: udata_front/theme/gouvfr/templates/reuse/display.html:43
 msgid "Private"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:55
+#: udata_front/theme/gouvfr/templates/dataset/display.html:54
 msgid "This dataset has been deleted. This will be permanent in the next 24 hours"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:55
+#: udata_front/theme/gouvfr/templates/dataset/display.html:54
 msgid "Deleted"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:59
+#: udata_front/theme/gouvfr/templates/dataset/display.html:58
 msgid ""
 "This dataset has been archived automatically because it has been deleted from"
 " the remote platform."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:61
+#: udata_front/theme/gouvfr/templates/dataset/display.html:60
 msgid "This dataset has been archived."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:63
+#: udata_front/theme/gouvfr/templates/dataset/display.html:62
 msgid "Archived"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:69
+#: udata_front/theme/gouvfr/templates/dataset/display.html:68
 msgid ""
 "This dataset is handled by the <a href='{geo_link}'>geo.data.gouv.fr</a> "
 "platform.\n"
@@ -629,16 +629,16 @@ msgid ""
 "geo.data.gouv.fr is available here.</a>"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:85
+#: udata_front/theme/gouvfr/templates/dataset/display.html:84
 #, python-format
 msgid "Updated on %(date)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:101
+#: udata_front/theme/gouvfr/templates/dataset/display.html:100
 msgid "Modify dataset"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:108
+#: udata_front/theme/gouvfr/templates/dataset/display.html:107
 #, python-format
 msgid ""
 "This dataset has been published on the initiative and under the "
@@ -646,128 +646,129 @@ msgid ""
 "            %(author)s<br />Published on %(date)s and updated on %(update)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:120
+#: udata_front/theme/gouvfr/templates/dataset/display.html:119
 msgid "Dataset informations"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:127
+#: udata_front/theme/gouvfr/templates/dataset/display.html:126
 msgid "Author"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:134
-#: udata_front/theme/gouvfr/templates/reuse/display.html:95
+#: udata_front/theme/gouvfr/templates/dataset/display.html:133
+#: udata_front/theme/gouvfr/templates/reuse/display.html:94
 msgid "Metadata"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:172
-#: udata_front/theme/gouvfr/templates/reuse/display.html:130
+#: udata_front/theme/gouvfr/templates/dataset/display.html:171
+#: udata_front/theme/gouvfr/templates/reuse/display.html:129
 msgid "Informations"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:175
+#: udata_front/theme/gouvfr/templates/dataset/display.html:174
 msgid "License"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:182
-#: udata_front/theme/gouvfr/templates/reuse/display.html:136
+#: udata_front/theme/gouvfr/templates/dataset/display.html:181
+#: udata_front/theme/gouvfr/templates/reuse/display.html:135
 msgid "ID"
 msgstr ""
 
+#: udata_front/theme/gouvfr/templates/dataset/display.html:186
 #: udata_front/theme/gouvfr/templates/dataset/display.html:187
-#: udata_front/theme/gouvfr/templates/dataset/display.html:188
 msgid "Remote source"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:193
+#: udata_front/theme/gouvfr/templates/dataset/display.html:192
 msgid "Temporality"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:199
-#: udata_front/theme/gouvfr/templates/organization/display.html:148
-#: udata_front/theme/gouvfr/templates/reuse/display.html:145
+#: udata_front/theme/gouvfr/templates/dataset/display.html:198
+#: udata_front/theme/gouvfr/templates/organization/display.html:131
+#: udata_front/theme/gouvfr/templates/reuse/display.html:144
 msgid "Creation date"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:201
+#: udata_front/theme/gouvfr/templates/dataset/display.html:200
 msgid "Latest resource update"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:207
+#: udata_front/theme/gouvfr/templates/dataset/display.html:206
 msgid "Geographic dimensions"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:210
+#: udata_front/theme/gouvfr/templates/dataset/display.html:209
 #: udata_front/theme/gouvfr/templates/dataset/search-result.html:61
 msgid "Territorial coverage granularity"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:214
+#: udata_front/theme/gouvfr/templates/dataset/display.html:213
 msgid "Territorial coverage"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:227
+#: udata_front/theme/gouvfr/templates/dataset/display.html:226
 msgid "Extras"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:243
+#: udata_front/theme/gouvfr/templates/dataset/display.html:242
 #: udata_front/theme/gouvfr/templates/participez/participez.html:5
-#: udata_front/theme/gouvfr/templates/reuse/display.html:155
+#: udata_front/theme/gouvfr/templates/reuse/display.html:154
 msgid "Participate"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:251
+#: udata_front/theme/gouvfr/templates/dataset/display.html:250
 #: udata_front/theme/gouvfr/templates/organization/sidebar-producer.html:31
 #: udata_front/theme/gouvfr/templates/user/sidebar-user.html:23
 msgid "Contact the producer"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:257
+#: udata_front/theme/gouvfr/templates/dataset/display.html:256
 #: udata_front/theme/gouvfr/templates/dataset/resource/card.html:63
-#: udata_front/theme/gouvfr/templates/reuse/display.html:169
+#: udata_front/theme/gouvfr/templates/reuse/display.html:168
 msgid "Permalink"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:273
-#: udata_front/theme/gouvfr/templates/reuse/display.html:185
+#: udata_front/theme/gouvfr/templates/dataset/display.html:272
+#: udata_front/theme/gouvfr/templates/reuse/display.html:184
 msgid "Summary"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:277
-#: udata_front/theme/gouvfr/templates/dataset/display.html:308
-#: udata_front/theme/gouvfr/templates/reuse/display.html:189
-#: udata_front/theme/gouvfr/templates/reuse/display.html:214
+#: udata_front/theme/gouvfr/templates/dataset/display.html:276
+#: udata_front/theme/gouvfr/templates/dataset/display.html:307
+#: udata_front/theme/gouvfr/templates/organization/display.html:74
+#: udata_front/theme/gouvfr/templates/reuse/display.html:188
+#: udata_front/theme/gouvfr/templates/reuse/display.html:213
 msgid "Description"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:287
-#: udata_front/theme/gouvfr/templates/dataset/display.html:354
+#: udata_front/theme/gouvfr/templates/dataset/display.html:286
+#: udata_front/theme/gouvfr/templates/dataset/display.html:353
 msgid "Community resources"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:318
+#: udata_front/theme/gouvfr/templates/dataset/display.html:317
 msgid "See also: community resources"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:339
+#: udata_front/theme/gouvfr/templates/dataset/display.html:338
 #, python-format
 msgid "See the %(nb)d resources of type %(type)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:344
+#: udata_front/theme/gouvfr/templates/dataset/display.html:343
 msgid "No resources"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:358
+#: udata_front/theme/gouvfr/templates/dataset/display.html:357
 msgid ""
 "You have built a more comprehensive database than those presented here? This "
 "is the time to share it!"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:371
+#: udata_front/theme/gouvfr/templates/dataset/display.html:370
 msgid "Add a community resource"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:381
+#: udata_front/theme/gouvfr/templates/dataset/display.html:380
 msgid ""
 "You reused these data and published an article, a computer graphics, or an "
 "application?\n"
@@ -776,8 +777,8 @@ msgid ""
 "visibility."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:409
-#: udata_front/theme/gouvfr/templates/reuse/display.html:241
+#: udata_front/theme/gouvfr/templates/dataset/display.html:408
+#: udata_front/theme/gouvfr/templates/reuse/display.html:240
 msgid "Discussion between the organization and the community about this dataset."
 msgstr ""
 
@@ -801,7 +802,7 @@ msgstr ""
 #: udata_front/theme/gouvfr/templates/dataset/list.html:19
 #: udata_front/theme/gouvfr/templates/organization/card.html:23
 #: udata_front/theme/gouvfr/templates/organization/producer-summary.html:38
-#: udata_front/theme/gouvfr/templates/reuse/card.html:16
+#: udata_front/theme/gouvfr/templates/reuse/card.html:19
 #: udata_front/theme/gouvfr/templates/topic/datasets.html:8
 msgid "datasets"
 msgstr ""
@@ -844,7 +845,6 @@ msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/search-result.html:74
 #: udata_front/theme/gouvfr/templates/organization/card.html:34
-#: udata_front/theme/gouvfr/templates/reuse/card.html:22
 msgid "favourites"
 msgstr ""
 
@@ -882,7 +882,7 @@ msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/resource/card.html:67
 #: udata_front/theme/gouvfr/templates/reuse/card_old.html:27
-#: udata_front/theme/gouvfr/templates/reuse/display.html:132
+#: udata_front/theme/gouvfr/templates/reuse/display.html:131
 msgid "Type"
 msgstr ""
 
@@ -1092,20 +1092,14 @@ msgid "%(user)s closed an discussion on your %(type)s %(subject)s"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/mail/discussion_closed.html:26
-#: udata_front/theme/gouvfr/templates/mail/issue_closed.html:26
 #: udata_front/theme/gouvfr/templates/mail/new_discussion.html:25
 #: udata_front/theme/gouvfr/templates/mail/new_discussion_comment.html:26
-#: udata_front/theme/gouvfr/templates/mail/new_issue.html:25
-#: udata_front/theme/gouvfr/templates/mail/new_issue_comment.html:26
 msgid "Title"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/mail/discussion_closed.html:31
-#: udata_front/theme/gouvfr/templates/mail/issue_closed.html:31
 #: udata_front/theme/gouvfr/templates/mail/new_discussion.html:30
 #: udata_front/theme/gouvfr/templates/mail/new_discussion_comment.html:31
-#: udata_front/theme/gouvfr/templates/mail/new_issue.html:29
-#: udata_front/theme/gouvfr/templates/mail/new_issue_comment.html:31
 msgid "Message"
 msgstr ""
 
@@ -1133,17 +1127,6 @@ msgstr ""
 
 #: udata_front/theme/gouvfr/templates/mail/frequency_reminder.html:25
 msgid "Update the dataset and associated resources"
-msgstr ""
-
-#: udata_front/theme/gouvfr/templates/mail/issue_closed.html:6
-#, python-format
-msgid "%(user)s closed an issue on your %(type)s %(subject)s"
-msgstr ""
-
-#: udata_front/theme/gouvfr/templates/mail/issue_closed.html:40
-#: udata_front/theme/gouvfr/templates/mail/new_issue.html:36
-#: udata_front/theme/gouvfr/templates/mail/new_issue_comment.html:39
-msgid "See the issue"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/mail/membership_refused.html:7
@@ -1191,16 +1174,6 @@ msgstr ""
 msgid "%(user)s followed your organization %(org)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/mail/new_issue.html:6
-#, python-format
-msgid "%(user)s submitted a new issue on your %(type)s %(subject)s"
-msgstr ""
-
-#: udata_front/theme/gouvfr/templates/mail/new_issue_comment.html:6
-#, python-format
-msgid "%(user)s commented an issue on your %(type)s %(subject)s"
-msgstr ""
-
 #: udata_front/theme/gouvfr/templates/mail/new_member.html:7
 #, python-format
 msgid "Congratulations, you are now a member of the organization \"%(org)s\""
@@ -1216,7 +1189,7 @@ msgid "A new reuse of your dataset %(dataset)s has been published"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/mail/new_reuse.html:31
-#: udata_front/theme/gouvfr/templates/reuse/display.html:77
+#: udata_front/theme/gouvfr/templates/reuse/display.html:76
 msgid "See the reuse"
 msgstr ""
 
@@ -1295,7 +1268,7 @@ msgstr ""
 msgid "Confirm now"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:11
+#: udata_front/theme/gouvfr/templates/organization/display.html:12
 msgid "organization"
 msgstr ""
 
@@ -1305,27 +1278,31 @@ msgid ""
 "hours"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:125
+#: udata_front/theme/gouvfr/templates/organization/display.html:67
+msgid "Modify organization"
+msgstr ""
+
+#: udata_front/theme/gouvfr/templates/organization/display.html:108
 msgid "Members"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:141
+#: udata_front/theme/gouvfr/templates/organization/display.html:124
 msgid "Technical details"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:152
+#: udata_front/theme/gouvfr/templates/organization/display.html:135
 msgid "Modification date"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:163
+#: udata_front/theme/gouvfr/templates/organization/display.html:146
 msgid "Modify information"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:168
+#: udata_front/theme/gouvfr/templates/organization/display.html:151
 msgid "Download list of datasets as csv file"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:182
+#: udata_front/theme/gouvfr/templates/organization/display.html:165
 msgid "Pending request to join this organization"
 msgstr ""
 
@@ -1416,7 +1393,7 @@ msgstr ""
 
 #: udata_front/theme/gouvfr/templates/post/display.html:27
 #: udata_front/theme/gouvfr/templates/reuse/card_old.html:41
-#: udata_front/theme/gouvfr/templates/reuse/display.html:59
+#: udata_front/theme/gouvfr/templates/reuse/display.html:58
 #, python-format
 msgid "Published on %(date)s"
 msgstr ""
@@ -1487,45 +1464,45 @@ msgstr ""
 msgid "Created by %(user)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:11
+#: udata_front/theme/gouvfr/templates/reuse/display.html:10
 msgid "reuse"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:43
+#: udata_front/theme/gouvfr/templates/reuse/display.html:42
 msgid "This reuse is private and will not be visible by other users"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:49
+#: udata_front/theme/gouvfr/templates/reuse/display.html:48
 msgid "This reuse has been deleted. This will be permanent in the next 24 hours"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:66
+#: udata_front/theme/gouvfr/templates/reuse/display.html:65
 msgid "Modify reuse"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:85
+#: udata_front/theme/gouvfr/templates/reuse/display.html:84
 msgid "Reuse informations"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:89
+#: udata_front/theme/gouvfr/templates/reuse/display.html:88
 msgid "Reuser"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:143
+#: udata_front/theme/gouvfr/templates/reuse/display.html:142
 msgid "Publication"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:163
+#: udata_front/theme/gouvfr/templates/reuse/display.html:162
 msgid "Contact the reuser"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:194
-#: udata_front/theme/gouvfr/templates/reuse/display.html:223
+#: udata_front/theme/gouvfr/templates/reuse/display.html:193
+#: udata_front/theme/gouvfr/templates/reuse/display.html:222
 msgid "Used datasets"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:204
-#: udata_front/theme/gouvfr/templates/reuse/display.html:250
+#: udata_front/theme/gouvfr/templates/reuse/display.html:203
+#: udata_front/theme/gouvfr/templates/reuse/display.html:249
 msgid "More reuses"
 msgstr ""
 

--- a/udata_front/theme/gouvfr/translations/gouvfr.pot
+++ b/udata_front/theme/gouvfr/translations/gouvfr.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: udata-front 1.1.3.dev0\n"
 "Report-Msgid-Bugs-To: data.gouv@data.gouv.fr\n"
-"POT-Creation-Date: 2021-12-06 15:05+0100\n"
-"PO-Revision-Date: 2021-12-06 15:05+0100\n"
+"POT-Creation-Date: 2021-12-09 16:25+0100\n"
+"PO-Revision-Date: 2021-12-09 16:25+0100\n"
 "Last-Translator: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
 "Language: en\n"
 "Language-Team: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
@@ -24,8 +24,8 @@ msgid "Data"
 msgstr ""
 
 #: udata_front/theme/gouvfr/__init__.py:47
-#: udata_front/theme/gouvfr/templates/dataset/display.html:292
-#: udata_front/theme/gouvfr/templates/dataset/display.html:377
+#: udata_front/theme/gouvfr/templates/dataset/display.html:293
+#: udata_front/theme/gouvfr/templates/dataset/display.html:378
 #: udata_front/theme/gouvfr/templates/hetic/page2.html:42
 #: udata_front/theme/gouvfr/templates/home.html:61
 #: udata_front/theme/gouvfr/templates/organization/display.html:56
@@ -124,7 +124,7 @@ msgid "Download from "
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/api/card.html:14
-#: udata_front/theme/gouvfr/templates/dataset/display.html:124
+#: udata_front/theme/gouvfr/templates/dataset/display.html:125
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:177
 msgid "Producer"
 msgstr ""
@@ -142,7 +142,7 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:254
+#: udata_front/theme/gouvfr/templates/dataset/display.html:255
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:206
 #: udata_front/theme/gouvfr/templates/reuse/display.html:166
 msgid "Embed"
@@ -165,7 +165,7 @@ msgstr ""
 msgid "Territory"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:195
+#: udata_front/theme/gouvfr/templates/dataset/display.html:196
 #: udata_front/theme/gouvfr/templates/dataset/search-result.html:46
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:232
 msgid "Frequency"
@@ -324,7 +324,7 @@ msgstr ""
 msgid "All news"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:32
+#: udata_front/theme/gouvfr/templates/dataset/display.html:33
 #: udata_front/theme/gouvfr/templates/dataset/explore.html:7
 #: udata_front/theme/gouvfr/templates/dataset/followers.html:4
 #: udata_front/theme/gouvfr/templates/dataset/list.html:17
@@ -343,8 +343,8 @@ msgstr ""
 msgid "Datasets"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:281
-#: udata_front/theme/gouvfr/templates/dataset/display.html:315
+#: udata_front/theme/gouvfr/templates/dataset/display.html:282
+#: udata_front/theme/gouvfr/templates/dataset/display.html:316
 #: udata_front/theme/gouvfr/templates/home.html:60
 #: udata_front/theme/gouvfr/templates/site/dashboard.html:21
 msgid "Resources"
@@ -359,8 +359,8 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:297
-#: udata_front/theme/gouvfr/templates/dataset/display.html:405
+#: udata_front/theme/gouvfr/templates/dataset/display.html:298
+#: udata_front/theme/gouvfr/templates/dataset/display.html:402
 #: udata_front/theme/gouvfr/templates/home.html:64
 #: udata_front/theme/gouvfr/templates/post/display.html:137
 #: udata_front/theme/gouvfr/templates/reuse/display.html:198
@@ -422,8 +422,8 @@ msgstr ""
 msgid "metrics"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:139
-#: udata_front/theme/gouvfr/templates/organization/display.html:141
+#: udata_front/theme/gouvfr/templates/dataset/display.html:140
+#: udata_front/theme/gouvfr/templates/organization/display.html:139
 #: udata_front/theme/gouvfr/templates/page.html:50
 #: udata_front/theme/gouvfr/templates/post/display.html:91
 #: udata_front/theme/gouvfr/templates/reuse/display.html:100
@@ -556,8 +556,8 @@ msgid "Due to security reasons, the creation of new content is currently disable
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/add-reuse-card.html:5
-#: udata_front/theme/gouvfr/templates/dataset/display.html:245
-#: udata_front/theme/gouvfr/templates/dataset/display.html:398
+#: udata_front/theme/gouvfr/templates/dataset/display.html:246
+#: udata_front/theme/gouvfr/templates/dataset/display.html:395
 #: udata_front/theme/gouvfr/templates/reuse/display.html:157
 msgid "Add a reuse"
 msgstr ""
@@ -576,50 +576,50 @@ msgstr ""
 msgid "reuses"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:11
+#: udata_front/theme/gouvfr/templates/dataset/display.html:12
 msgid "dataset"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:17
+#: udata_front/theme/gouvfr/templates/dataset/display.html:18
 #: udata_front/theme/gouvfr/templates/reuse/display.html:18
 #, python-format
 msgid "Explore with %(certifier)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:49
+#: udata_front/theme/gouvfr/templates/dataset/display.html:50
 msgid "This dataset is private and will not be visible by other users"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:49
+#: udata_front/theme/gouvfr/templates/dataset/display.html:50
 #: udata_front/theme/gouvfr/templates/dataset/search-result.html:28
 #: udata_front/theme/gouvfr/templates/reuse/card.html:23
 #: udata_front/theme/gouvfr/templates/reuse/display.html:43
 msgid "Private"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:54
+#: udata_front/theme/gouvfr/templates/dataset/display.html:55
 msgid "This dataset has been deleted. This will be permanent in the next 24 hours"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:54
+#: udata_front/theme/gouvfr/templates/dataset/display.html:55
 msgid "Deleted"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:58
+#: udata_front/theme/gouvfr/templates/dataset/display.html:59
 msgid ""
 "This dataset has been archived automatically because it has been deleted from"
 " the remote platform."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:60
+#: udata_front/theme/gouvfr/templates/dataset/display.html:61
 msgid "This dataset has been archived."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:62
+#: udata_front/theme/gouvfr/templates/dataset/display.html:63
 msgid "Archived"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:68
+#: udata_front/theme/gouvfr/templates/dataset/display.html:69
 msgid ""
 "This dataset is handled by the <a href='{geo_link}'>geo.data.gouv.fr</a> "
 "platform.\n"
@@ -629,16 +629,16 @@ msgid ""
 "geo.data.gouv.fr is available here.</a>"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:84
+#: udata_front/theme/gouvfr/templates/dataset/display.html:85
 #, python-format
 msgid "Updated on %(date)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:100
+#: udata_front/theme/gouvfr/templates/dataset/display.html:101
 msgid "Modify dataset"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:107
+#: udata_front/theme/gouvfr/templates/dataset/display.html:108
 #, python-format
 msgid ""
 "This dataset has been published on the initiative and under the "
@@ -646,138 +646,137 @@ msgid ""
 "            %(author)s<br />Published on %(date)s and updated on %(update)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:119
+#: udata_front/theme/gouvfr/templates/dataset/display.html:120
 msgid "Dataset informations"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:126
+#: udata_front/theme/gouvfr/templates/dataset/display.html:127
 msgid "Author"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:133
+#: udata_front/theme/gouvfr/templates/dataset/display.html:134
 #: udata_front/theme/gouvfr/templates/reuse/display.html:94
 msgid "Metadata"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:171
+#: udata_front/theme/gouvfr/templates/dataset/display.html:172
 #: udata_front/theme/gouvfr/templates/reuse/display.html:129
 msgid "Informations"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:174
+#: udata_front/theme/gouvfr/templates/dataset/display.html:175
 msgid "License"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:181
+#: udata_front/theme/gouvfr/templates/dataset/display.html:182
 #: udata_front/theme/gouvfr/templates/reuse/display.html:135
 msgid "ID"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:186
 #: udata_front/theme/gouvfr/templates/dataset/display.html:187
+#: udata_front/theme/gouvfr/templates/dataset/display.html:188
 msgid "Remote source"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:192
+#: udata_front/theme/gouvfr/templates/dataset/display.html:193
 msgid "Temporality"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:198
-#: udata_front/theme/gouvfr/templates/organization/display.html:131
+#: udata_front/theme/gouvfr/templates/dataset/display.html:199
+#: udata_front/theme/gouvfr/templates/organization/display.html:129
 #: udata_front/theme/gouvfr/templates/reuse/display.html:144
 msgid "Creation date"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:200
+#: udata_front/theme/gouvfr/templates/dataset/display.html:201
 msgid "Latest resource update"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:206
+#: udata_front/theme/gouvfr/templates/dataset/display.html:207
 msgid "Geographic dimensions"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:209
+#: udata_front/theme/gouvfr/templates/dataset/display.html:210
 #: udata_front/theme/gouvfr/templates/dataset/search-result.html:61
 msgid "Territorial coverage granularity"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:213
+#: udata_front/theme/gouvfr/templates/dataset/display.html:214
 msgid "Territorial coverage"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:226
+#: udata_front/theme/gouvfr/templates/dataset/display.html:227
 msgid "Extras"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:242
+#: udata_front/theme/gouvfr/templates/dataset/display.html:243
 #: udata_front/theme/gouvfr/templates/participez/participez.html:5
 #: udata_front/theme/gouvfr/templates/reuse/display.html:154
 msgid "Participate"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:250
+#: udata_front/theme/gouvfr/templates/dataset/display.html:251
 #: udata_front/theme/gouvfr/templates/organization/sidebar-producer.html:31
 #: udata_front/theme/gouvfr/templates/user/sidebar-user.html:23
 msgid "Contact the producer"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:256
+#: udata_front/theme/gouvfr/templates/dataset/display.html:257
 #: udata_front/theme/gouvfr/templates/dataset/resource/card.html:63
 #: udata_front/theme/gouvfr/templates/reuse/display.html:168
 msgid "Permalink"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:272
+#: udata_front/theme/gouvfr/templates/dataset/display.html:273
 #: udata_front/theme/gouvfr/templates/reuse/display.html:184
 msgid "Summary"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:276
-#: udata_front/theme/gouvfr/templates/dataset/display.html:307
+#: udata_front/theme/gouvfr/templates/dataset/display.html:277
+#: udata_front/theme/gouvfr/templates/dataset/display.html:308
 #: udata_front/theme/gouvfr/templates/organization/display.html:74
 #: udata_front/theme/gouvfr/templates/reuse/display.html:188
 #: udata_front/theme/gouvfr/templates/reuse/display.html:213
 msgid "Description"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:286
-#: udata_front/theme/gouvfr/templates/dataset/display.html:353
+#: udata_front/theme/gouvfr/templates/dataset/display.html:287
+#: udata_front/theme/gouvfr/templates/dataset/display.html:354
 msgid "Community resources"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:317
+#: udata_front/theme/gouvfr/templates/dataset/display.html:318
 msgid "See also: community resources"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:338
+#: udata_front/theme/gouvfr/templates/dataset/display.html:339
 #, python-format
 msgid "See the %(nb)d resources of type %(type)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:343
+#: udata_front/theme/gouvfr/templates/dataset/display.html:344
 msgid "No resources"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:357
+#: udata_front/theme/gouvfr/templates/dataset/display.html:358
 msgid ""
 "You have built a more comprehensive database than those presented here? This "
 "is the time to share it!"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:370
+#: udata_front/theme/gouvfr/templates/dataset/display.html:371
 msgid "Add a community resource"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:380
-msgid ""
-"You reused these data and published an article, a computer graphics, or an "
-"application?\n"
-"                It's time to let you know!\n"
-"                Reference your work in just a few clicks and increase your "
-"visibility."
+#: udata_front/theme/gouvfr/templates/dataset/display.html:379
+msgid "Explore the reuses of this dataset."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:408
+#: udata_front/theme/gouvfr/templates/dataset/display.html:380
+msgid "Did you use this data ? Reference your work and increase your visibility."
+msgstr ""
+
+#: udata_front/theme/gouvfr/templates/dataset/display.html:405
 #: udata_front/theme/gouvfr/templates/reuse/display.html:240
 msgid "Discussion between the organization and the community about this dataset."
 msgstr ""
@@ -1282,27 +1281,27 @@ msgstr ""
 msgid "Modify organization"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:108
+#: udata_front/theme/gouvfr/templates/organization/display.html:106
 msgid "Members"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:124
+#: udata_front/theme/gouvfr/templates/organization/display.html:122
 msgid "Technical details"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:135
+#: udata_front/theme/gouvfr/templates/organization/display.html:133
 msgid "Modification date"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:146
+#: udata_front/theme/gouvfr/templates/organization/display.html:144
 msgid "Modify information"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:151
+#: udata_front/theme/gouvfr/templates/organization/display.html:149
 msgid "Download list of datasets as csv file"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:165
+#: udata_front/theme/gouvfr/templates/organization/display.html:163
 msgid "Pending request to join this organization"
 msgstr ""
 

--- a/udata_front/theme/gouvfr/translations/gouvfr.pot
+++ b/udata_front/theme/gouvfr/translations/gouvfr.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: udata-front 1.1.3.dev0\n"
 "Report-Msgid-Bugs-To: data.gouv@data.gouv.fr\n"
-"POT-Creation-Date: 2021-12-06 14:52+0100\n"
-"PO-Revision-Date: 2021-12-06 14:52+0100\n"
+"POT-Creation-Date: 2021-12-06 15:05+0100\n"
+"PO-Revision-Date: 2021-12-06 15:05+0100\n"
 "Last-Translator: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
 "Language: en\n"
 "Language-Team: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
@@ -1504,6 +1504,10 @@ msgstr ""
 #: udata_front/theme/gouvfr/templates/reuse/display.html:203
 #: udata_front/theme/gouvfr/templates/reuse/display.html:249
 msgid "More reuses"
+msgstr ""
+
+#: udata_front/theme/gouvfr/templates/reuse/display.html:250
+msgid "Discover more reuses."
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/reuse/list.html:6

--- a/udata_front/views/organization.py
+++ b/udata_front/views/organization.py
@@ -62,7 +62,7 @@ class ProtectedOrgView(OrgView):
 @blueprint.route('/<org:org>/', endpoint='show')
 class OrganizationDetailView(OrgView, DetailView):
     template_name = 'organization/display.html'
-    page_size = 10
+    page_size = 4
 
     def get_context(self):
         context = super(OrganizationDetailView, self).get_context()


### PR DESCRIPTION
Close https://github.com/etalab/data.gouv.fr/issues/577

This update reuses lists on display pages :
- 4 displayed
- with a pagination
- taller and thinner
- they have a fixed width instead of a width based on the viewport (not sure about this)