### PR TITLE
Fix modals not displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix modals not working [#71](https://github.com/etalab/udata-front/pull/71)
 
 ## 1.2.2 (2022-01-21)
 

--- a/theme/less/specific/suggest.less
+++ b/theme/less/specific/suggest.less
@@ -107,7 +107,6 @@
 #app {
     // Prepare elements for shifting
     > *:not(.site-header):not(.banner) {
-        will-change: transform, filter, opacity;
         transition: @suggest-transition;
         transition-property: transform, filter, opacity;
     }


### PR DESCRIPTION
In https://github.com/etalab/udata-front/pull/56, I fixed this `will-change` CSS property. It was missing commas to be valid.
But this property introduce a new stacking context for `<main>` which conflict with our modal system. 

The goal of `will-change` is to tell browsers that some properties will change so they can better optimise the changes. This create new stacking contexts for all children of `#app` (except `.site-header`) because the value contains `transform`, `filter` and `opacity` (details about stacking context can be found [on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context)). Our `<main>` got a new stacking context so the `position: absolute` is placed based on this context and not the default one.

Default browser optimisation seems to work fine for the suggest transition so I removed the `will-change` property.

Close https://github.com/etalab/data.gouv.fr/issues/681