### PR TITLE
Change link to the Github logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - `.dropdown` is removed. Use DSFR select instead.
 - Fix duplicate request on dataset search [#70](https://github.com/etalab/udata-front/pull/70)
 - Add banner for harvested dataset [#73](https://github.com/etalab/udata-front/pull/73)
+- Change github footer link to the tickets repository [#80](https://github.com/etalab/udata-front/pull/80)
 
 ## 1.2.3 (2022-01-27)
 

--- a/udata_front/theme/gouvfr/templates/footer.html
+++ b/udata_front/theme/gouvfr/templates/footer.html
@@ -40,7 +40,7 @@
                             </a>
                         </li>
                         <li class="fr-ml-9v">
-                            <a href="https://github.com/etalab" title="Github">
+                            <a href="https://github.com/etalab/data.gouv.fr/" title="Github">
                                 {% include theme('svg/socials/github.svg') %}
                             </a>
                         </li>


### PR DESCRIPTION
Change link in favor of https://github.com/etalab/data.gouv.fr/ in order to get feedback 🤞 
Inspired by https://github.com/etalab/data.gouv.fr/issues/412