### PR TITLE
Fix read-more showing when not required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Current (in progress)
 
 - Remove topics code [#59](https://github.com/etalab/udata-front/pull/59)
-- Fix `<read-more>` component height when it contains `<img>` [65](https://github.com/etalab/udata-front/pull/65)
+- Fix `<read-more>` component height when it contains `<img>` [65](https://github.com/etalab/udata-front/pull/65) [85](https://github.com/etalab/udata-front/pull/85)
 - Add featured button component back for sysadmin [#79](https://github.com/etalab/udata-front/pull/79)
 - Update reuse style [#52](https://github.com/etalab/udata-front/pull/52) [#81](https://github.com/etalab/udata-front/pull/81)
 - Add banner to broken user page [#76](https://github.com/etalab/udata-front/pull/76)

--- a/theme/js/components/utils/read-more.vue
+++ b/theme/js/components/utils/read-more.vue
@@ -30,7 +30,7 @@ function getHeight(elt) {
     parseFloat(style.getPropertyValue('margin-bottom'));
 }
 
-const DEFAULT_HEIGHT = 284
+const DEFAULT_HEIGHT = 284;
 
 export default {
   name: "read-more",
@@ -72,8 +72,8 @@ export default {
       let contentHeight = Array.from(this.$refs.container.children)
       .map(getHeight)
       .reduce((total, height) => total + height, 0)
-      this.readMoreRequired = contentHeight > getHeight(this.$refs.container);
       this.containerHeight = DEFAULT_HEIGHT;
+      this.readMoreRequired = Math.round(contentHeight) > this.containerHeight;
       if(!this.readMoreRequired) {
         this.containerHeight = contentHeight;
       }

--- a/theme/js/components/utils/read-more.vue
+++ b/theme/js/components/utils/read-more.vue
@@ -73,7 +73,7 @@ export default {
       .map(getHeight)
       .reduce((total, height) => total + height, 0)
       this.containerHeight = DEFAULT_HEIGHT;
-      this.readMoreRequired = Math.round(contentHeight) > this.containerHeight;
+      this.readMoreRequired = contentHeight > this.containerHeight;
       if(!this.readMoreRequired) {
         this.containerHeight = contentHeight;
       }


### PR DESCRIPTION
I tested with descriptions from the following datasets / reuses :
- datasets/le-capital-au-xxie-siecle/
- datasets/fichier-des-personnes-decedees/
- datasets/demandes-de-valeurs-foncieres/
- datasets/mairie-de-beynost-borne-de-recharge-pour-vehicules-electriques-1/
- reuses/datafrance-plateforme-de-visualisation-open-data/
- datasets/courbes-de-niveau-4/