### PR TITLE
Let browsers decide what cursor to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Let browsers decide what cursor to use [#89](https://github.com/etalab/udata-front/pull/89)
 
 ## 1.2.4 (2022-03-01)
 
 - **Deprecation**: Topics are now deprecated and will be removed in upcoming releases.
-- Fix `<read-more>` component height when it contains `<img>` [65](https://github.com/etalab/udata-front/pull/65) [85](https://github.com/etalab/udata-front/pull/85)
+- Fix `<read-more>` component height when it contains `<img>` [#65](https://github.com/etalab/udata-front/pull/65) [85](https://github.com/etalab/udata-front/pull/85)
 - Add featured button component back for sysadmin [#79](https://github.com/etalab/udata-front/pull/79)
 - Update reuse style [#52](https://github.com/etalab/udata-front/pull/52) [#81](https://github.com/etalab/udata-front/pull/81)
 - Add banner to broken user page [#76](https://github.com/etalab/udata-front/pull/76)

--- a/theme/less/override.less
+++ b/theme/less/override.less
@@ -1,6 +1,11 @@
-//Preventing annoying horizontal scroll because of the negative margins of the grid
+// Preventing annoying horizontal scroll because of the negative margins of the grid
 body {
     overflow-x: hidden;
+}
+
+// This is the default for browsers and it's the value used in the DSFR
+html {
+    cursor: auto;
 }
 
 ul {


### PR DESCRIPTION
This change overrides sanitize.css default to be in sync with DSFR and let browsers decide the cursor to use for each tag.

Close https://github.com/etalab/data.gouv.fr/issues/419