### PR TITLE
Add transport banner hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add a transport banner hook [#94](https://github.com/etalab/udata-front/pull/94)
 
 ## 1.2.4 (2022-03-01)
 

--- a/udata_front/theme/gouvfr/templates/dataset/display.html
+++ b/udata_front/theme/gouvfr/templates/dataset/display.html
@@ -125,6 +125,7 @@
             .format(external_source=external_source)
         )}}
     {% endif %}
+    {{ hook('dataset.display.transport-banner') }}
     {% if dataset.owner %}
     <div class="row">
         <div class="well well-grey-100 col fr-py-3v">


### PR DESCRIPTION
Following the new [udata-transport plugin](https://github.com/opendatateam/udata-transport/pull/1), add a hook for the transport banner.

Example:
![image](https://user-images.githubusercontent.com/28541902/158417555-5709298f-3cb0-421a-b77d-05b4c51d7a5c.png)
