### PR TITLE
Add new menu items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix RGAA criterion 11.10 [#102](https://github.com/etalab/udata-front/pull/102)
 - Update DSFR to 1.5.1 [#107](https://github.com/etalab/udata-front/pull/107)
   -  :warning: SVG in JS must use `bundle-text:` prefix now
+- Add new menu items [#113](https://github.com/etalab/udata-front/pull/113)
 
 ## 2.0.2 (2022-04-11)
 

--- a/theme/less/components/tabs.less
+++ b/theme/less/components/tabs.less
@@ -72,8 +72,8 @@ You can use tabs from DSFR. It uses DSFR colors and conventions. It allows you t
 .fr-tabs {
     --text-active-blue-france: @blue-400;
     --border-active-blue-france: @blue-400;
-    --background-action-low-blue-france: @background-alt-blue-cumulus;
-    --background-action-low-blue-france-hover: @background-alt-blue-cumulus-hover;
-    --background-action-low-blue-france-active: @background-alt-blue-cumulus-active;
+    --background-action-low-blue-france: @background-action-low-blue-cumulus;
+    --background-action-low-blue-france-hover: @background-action-low-blue-cumulus-hover;
+    --background-action-low-blue-france-active: @background-action-low-blue-cumulus-active;
     z-index: 1;
 }

--- a/theme/less/components/tags.less
+++ b/theme/less/components/tags.less
@@ -29,9 +29,9 @@ There is also `.fr-tags-group` to group multiple tags together like a row.
 
 a.fr-tag, button.fr-tag {
     --text-action-high-blue-france: var(--text-default-info);
-    --background-action-low-blue-france: var(--background-contrast-info);
-    --background-action-low-blue-france-hover: var(--background-contrast-info-hover);
-    --background-action-low-blue-france-active: var(--background-contrast-info-active);
+    --background-action-low-blue-france: @background-action-low-blue-cumulus;
+    --background-action-low-blue-france-hover: @background-action-low-blue-cumulus-hover;
+    --background-action-low-blue-france-active: @background-action-low-blue-cumulus-active;
     --background-action-high-blue-france-hover: @blue-400-hover;
     --background-action-high-blue-france-active: @blue-400-active;
 

--- a/theme/less/content/colors.less
+++ b/theme/less/content/colors.less
@@ -100,6 +100,9 @@ Similar to the contextual text color classes, easily set the background of an el
 @background-alt-blue-cumulus: var(--background-alt-blue-cumulus);
 @background-alt-blue-cumulus-hover: var(--background-alt-blue-cumulus-hover);
 @background-alt-blue-cumulus-active: var(--background-alt-blue-cumulus-active);
+@background-action-low-blue-cumulus: var(--background-action-low-blue-cumulus);
+@background-action-low-blue-cumulus-hover: var(--background-action-low-blue-cumulus-hover);
+@background-action-low-blue-cumulus-active: var(--background-action-low-blue-cumulus-active);
 @background-alt-green-tilleul-verveine: var(--background-alt-green-tilleul-verveine);
 
 @border-default-grey: var(--border-default-grey);

--- a/theme/less/specific/header.less
+++ b/theme/less/specific/header.less
@@ -39,3 +39,9 @@
         fill: @blue-400;
     }
 }
+
+.fr-nav__btn[aria-expanded="true"] {
+    --background-open-blue-france: @background-action-low-blue-cumulus;
+    --background-open-blue-france-hover: @background-action-low-blue-cumulus-hover;
+    --background-open-blue-france-active: @background-action-low-blue-cumulus-active;
+}

--- a/udata_front/frontend/__init__.py
+++ b/udata_front/frontend/__init__.py
@@ -42,7 +42,7 @@ def init_app(app):
     nav.init_app(app)
     theme.init_app(app)
 
-    from . import helpers, error_handlers, resource_helpers  # noqa
+    from . import helpers, error_handlers, menu_helpers, resource_helpers  # noqa
 
     for view in VIEWS:
         _load_views(app, 'udata_front.views.{}'.format(view))

--- a/udata_front/frontend/menu_helpers.py
+++ b/udata_front/frontend/menu_helpers.py
@@ -24,5 +24,4 @@ def is_current_page(request: Request, item: Item) -> bool:
 
 @front.app_template_global()
 def is_parent_of_current_endpoint(request: Request, items: List[Item]) -> bool:
-    current_item_in_items = map(lambda item: is_current_page(request, item), items)
-    return any(current_item_in_items)
+    return any(is_current_page(request, item) for item in items)

--- a/udata_front/frontend/menu_helpers.py
+++ b/udata_front/frontend/menu_helpers.py
@@ -10,7 +10,7 @@ def get_current_endpoint(request: Request):
 @front.app_template_global()
 def is_current_endpoint(request: Request, item: Item) -> bool:
     current_endpoint = get_current_endpoint(request)
-    item_endpoint = item.endpoint and item.endpoint.split('.')[:1] 
+    item_endpoint = item.endpoint and item.endpoint.split('.')[:1]
     return request.url_rule.endpoint != "site.home" and (item_endpoint == current_endpoint)
 
 

--- a/udata_front/frontend/menu_helpers.py
+++ b/udata_front/frontend/menu_helpers.py
@@ -1,0 +1,24 @@
+from xmlrpc.client import Boolean
+from udata_front.frontend import front
+from flask_navigation.item import Item
+from flask import Request
+
+def get_current_endpoint(request: Request):
+    return request.url_rule.endpoint.split('.')[:1] if request.url_rule else None
+
+
+@front.app_template_global()
+def is_current_endpoint(request: Request, item: Item) -> Boolean:
+    current_endpoint = get_current_endpoint(request)
+    item_endpoint = item.endpoint and item.endpoint.split('.')[:1] 
+    return request.url_rule.endpoint != "site.home" and (item_endpoint == current_endpoint)
+
+@front.app_template_global()
+def is_current_page(request: Request, item: Item) -> Boolean:
+    return is_current_endpoint(request, item) and item.args == request.view_args
+
+
+@front.app_template_global()
+def is_parent_of_current_endpoint(request: Request, items: list[Item]) -> Boolean:
+    current_item_in_items = map(lambda item: is_current_page(request, item), items)
+    return any(current_item_in_items)

--- a/udata_front/frontend/menu_helpers.py
+++ b/udata_front/frontend/menu_helpers.py
@@ -1,6 +1,9 @@
-from udata_front.frontend import front
+from typing import List
+
 from flask_navigation.item import Item
 from flask import Request
+
+from udata_front.frontend import front
 
 
 def get_current_endpoint(request: Request):
@@ -20,6 +23,6 @@ def is_current_page(request: Request, item: Item) -> bool:
 
 
 @front.app_template_global()
-def is_parent_of_current_endpoint(request: Request, items: list[Item]) -> bool:
+def is_parent_of_current_endpoint(request: Request, items: List[Item]) -> bool:
     current_item_in_items = map(lambda item: is_current_page(request, item), items)
     return any(current_item_in_items)

--- a/udata_front/frontend/menu_helpers.py
+++ b/udata_front/frontend/menu_helpers.py
@@ -1,4 +1,3 @@
-from xmlrpc.client import Boolean
 from udata_front.frontend import front
 from flask_navigation.item import Item
 from flask import Request
@@ -8,17 +7,17 @@ def get_current_endpoint(request: Request):
 
 
 @front.app_template_global()
-def is_current_endpoint(request: Request, item: Item) -> Boolean:
+def is_current_endpoint(request: Request, item: Item) -> bool:
     current_endpoint = get_current_endpoint(request)
     item_endpoint = item.endpoint and item.endpoint.split('.')[:1] 
     return request.url_rule.endpoint != "site.home" and (item_endpoint == current_endpoint)
 
 @front.app_template_global()
-def is_current_page(request: Request, item: Item) -> Boolean:
+def is_current_page(request: Request, item: Item) -> bool:
     return is_current_endpoint(request, item) and item.args == request.view_args
 
 
 @front.app_template_global()
-def is_parent_of_current_endpoint(request: Request, items: list[Item]) -> Boolean:
+def is_parent_of_current_endpoint(request: Request, items: list[Item]) -> bool:
     current_item_in_items = map(lambda item: is_current_page(request, item), items)
     return any(current_item_in_items)

--- a/udata_front/frontend/menu_helpers.py
+++ b/udata_front/frontend/menu_helpers.py
@@ -2,6 +2,7 @@ from udata_front.frontend import front
 from flask_navigation.item import Item
 from flask import Request
 
+
 def get_current_endpoint(request: Request):
     return request.url_rule.endpoint.split('.')[:1] if request.url_rule else None
 
@@ -11,6 +12,7 @@ def is_current_endpoint(request: Request, item: Item) -> bool:
     current_endpoint = get_current_endpoint(request)
     item_endpoint = item.endpoint and item.endpoint.split('.')[:1] 
     return request.url_rule.endpoint != "site.home" and (item_endpoint == current_endpoint)
+
 
 @front.app_template_global()
 def is_current_page(request: Request, item: Item) -> bool:

--- a/udata_front/theme/gouvfr/__init__.py
+++ b/udata_front/theme/gouvfr/__init__.py
@@ -47,7 +47,7 @@ gouvfr_menu = nav.Bar('gouvfr_menu', [
     nav.Item(_('Reuses'), 'reuses.list'),
     nav.Item(_('Organizations'), 'organizations.list'),
     nav.Item(_('News'), 'posts.list'),
-    nav.Item(_('Starting on data.gouv.fr'), None, items=[
+    nav.Item(_('Getting started on data.gouv.fr'), None, items=[
         nav.Item(
             _('What is data.gouv.fr?'),
             'gouvfr.show_page',

--- a/udata_front/theme/gouvfr/__init__.py
+++ b/udata_front/theme/gouvfr/__init__.py
@@ -48,9 +48,21 @@ gouvfr_menu = nav.Bar('gouvfr_menu', [
     nav.Item(_('Organizations'), 'organizations.list'),
     nav.Item(_('News'), 'posts.list'),
     nav.Item(_('Starting on data.gouv.fr'), None, items=[
-        nav.Item(_('What is data.gouv.fr?'), 'gouvfr.show_page', args={'slug': 'about/ressources'}),
-        nav.Item(_('Why publish data ?'), 'gouvfr.show_page', args={'slug': 'onboarding/producteurs'}),
-        nav.Item(_('Why use data ?'), 'gouvfr.show_page', args={'slug': 'onboarding/reutilisateurs'}),
+        nav.Item(
+            _('What is data.gouv.fr?'),
+            'gouvfr.show_page',
+            args={'slug': 'about/ressources'}
+        ),
+        nav.Item(
+            _('Why publish data ?'),
+            'gouvfr.show_page',
+            args={'slug': 'onboarding/producteurs'}
+        ),
+        nav.Item(
+            _('Why use data ?'),
+            'gouvfr.show_page',
+            args={'slug': 'onboarding/reutilisateurs'}
+        ),
     ]),
     nav.Item(_('Contact us'), None, url='https://support.data.gouv.fr/'),
 ])

--- a/udata_front/theme/gouvfr/__init__.py
+++ b/udata_front/theme/gouvfr/__init__.py
@@ -54,12 +54,12 @@ gouvfr_menu = nav.Bar('gouvfr_menu', [
             args={'slug': 'about/ressources'}
         ),
         nav.Item(
-            _('Why publish data ?'),
+            _('How to publish data ?'),
             'gouvfr.show_page',
             args={'slug': 'onboarding/producteurs'}
         ),
         nav.Item(
-            _('Why use data ?'),
+            _('How to use data ?'),
             'gouvfr.show_page',
             args={'slug': 'onboarding/reutilisateurs'}
         ),

--- a/udata_front/theme/gouvfr/__init__.py
+++ b/udata_front/theme/gouvfr/__init__.py
@@ -47,7 +47,11 @@ gouvfr_menu = nav.Bar('gouvfr_menu', [
     nav.Item(_('Reuses'), 'reuses.list'),
     nav.Item(_('Organizations'), 'organizations.list'),
     nav.Item(_('News'), 'posts.list'),
-    nav.Item(_('About'), 'gouvfr.show_page', args={'slug': 'about/ressources'}),
+    nav.Item(_('Starting on data.gouv.fr'), None, items=[
+        nav.Item(_('What is data.gouv.fr?'), 'gouvfr.show_page', args={'slug': 'about/ressources'}),
+        nav.Item(_('Why publish data ?'), 'gouvfr.show_page', args={'slug': 'onboarding/producteurs'}),
+        nav.Item(_('Why use data ?'), 'gouvfr.show_page', args={'slug': 'onboarding/reutilisateurs'}),
+    ]),
     nav.Item(_('Contact us'), None, url='https://support.data.gouv.fr/'),
 ])
 

--- a/udata_front/theme/gouvfr/templates/header.html
+++ b/udata_front/theme/gouvfr/templates/header.html
@@ -160,11 +160,31 @@
             <div class="fr-header__menu-links"></div>
             <nav class="fr-nav" id="navigation" role="navigation" aria-label="{{ _('Main Menu') }}">
                 <ul class="fr-nav__list">
-                    {% set current_endpoint = request.url_rule.endpoint.split('.')[:1] if request.url_rule or None %}
                     {% for item in current_theme.menu %}
-                        {% set link_endpoint = item.endpoint and item.endpoint.split('.')[:1] %}
-                        {% set active = request.url_rule.endpoint != "site.home" and (link_endpoint == current_endpoint) %}
+                        {% set active = is_current_endpoint(request, item) %}
                         <li class="fr-nav__item">
+                            {% if item.items %}
+                            {% set id = item.label %}
+                            {% set active = is_parent_of_current_endpoint(request, item.items) %}
+                            <button class="fr-nav__btn" aria-expanded="false" aria-controls="{{ id }}" {% if active %}aria-current="true"{% endif %}>{{item.label}}</button>
+                            <div class="fr-collapse fr-menu" id="{{ id }}">
+                                <ul class="fr-menu__list">
+                                    {% for subitem in item.items %}
+                                    {% set active = is_current_page(request, subitem) %}
+                                    <li>
+                                        <a
+                                            class="fr-nav__link"
+                                            href="{{subitem.url}}"
+                                            {% if active %}aria-current="page"{% endif %}
+                                            target="_self"
+                                        >
+                                            {{ subitem.label }}
+                                        </a>
+                                    </li>
+                                    {% endfor %}
+                                </ul>
+                            </div>
+                            {% else %}
                             <a
                                 class="fr-nav__link"
                                 href="{{item.url}}"
@@ -173,6 +193,7 @@
                             >
                                 {{ item.label }}
                             </a>
+                            {% endif %}
                         </li>
                     {% endfor %}
                 </ul>

--- a/udata_front/theme/gouvfr/translations/gouvfr.pot
+++ b/udata_front/theme/gouvfr/translations/gouvfr.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: udata-front 2.0.3.dev0\n"
 "Report-Msgid-Bugs-To: data.gouv@data.gouv.fr\n"
-"POT-Creation-Date: 2022-05-24 15:03+0200\n"
-"PO-Revision-Date: 2022-05-24 15:03+0200\n"
+"POT-Creation-Date: 2022-06-07 14:53+0200\n"
+"PO-Revision-Date: 2022-06-07 14:53+0200\n"
 "Last-Translator: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
 "Language: en\n"
 "Language-Team: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
 
-#: udata_front/models.py:16 udata_front/theme/gouvfr/__init__.py:58
+#: udata_front/models.py:16 udata_front/theme/gouvfr/__init__.py:74
 msgid "Reference Data"
 msgstr ""
 
@@ -47,18 +47,18 @@ msgid "%(start)s to %(end)s"
 msgstr ""
 
 #: udata_front/theme/gouvfr/__init__.py:46
-#: udata_front/theme/gouvfr/templates/dataset/display.html:432
+#: udata_front/theme/gouvfr/templates/dataset/display.html:444
 #: udata_front/views/site.py:193
 msgid "Data"
 msgstr ""
 
 #: udata_front/theme/gouvfr/__init__.py:47
-#: udata_front/theme/gouvfr/templates/dataset/display.html:342
-#: udata_front/theme/gouvfr/templates/dataset/display.html:458
+#: udata_front/theme/gouvfr/templates/dataset/display.html:354
+#: udata_front/theme/gouvfr/templates/dataset/display.html:470
 #: udata_front/theme/gouvfr/templates/dataset/list.html:26
 #: udata_front/theme/gouvfr/templates/home.html:70
 #: udata_front/theme/gouvfr/templates/organization/display.html:56
-#: udata_front/theme/gouvfr/templates/organization/display.html:114
+#: udata_front/theme/gouvfr/templates/organization/display.html:118
 #: udata_front/theme/gouvfr/templates/organization/list.html:30
 #: udata_front/theme/gouvfr/templates/page.html:39
 #: udata_front/theme/gouvfr/templates/post/display.html:79
@@ -88,58 +88,70 @@ msgstr ""
 msgid "Organizations"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:49 udata_front/theme/gouvfr/__init__.py:57
+#: udata_front/theme/gouvfr/__init__.py:49 udata_front/theme/gouvfr/__init__.py:73
 #: udata_front/theme/gouvfr/templates/home.html:47
 #: udata_front/theme/gouvfr/templates/post/display.html:17
 msgid "News"
 msgstr ""
 
 #: udata_front/theme/gouvfr/__init__.py:50
-msgid "About"
+msgid "Starting on data.gouv.fr"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:51 udata_front/theme/gouvfr/__init__.py:81
+#: udata_front/theme/gouvfr/__init__.py:52
+msgid "What is data.gouv.fr?"
+msgstr ""
+
+#: udata_front/theme/gouvfr/__init__.py:57
+msgid "How to publish data ?"
+msgstr ""
+
+#: udata_front/theme/gouvfr/__init__.py:62
+msgid "How to use data ?"
+msgstr ""
+
+#: udata_front/theme/gouvfr/__init__.py:67 udata_front/theme/gouvfr/__init__.py:97
 msgid "Contact us"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:59
+#: udata_front/theme/gouvfr/__init__.py:75
 #: udata_front/theme/gouvfr/templates/home.html:20
 msgid "Featured topics"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:60
+#: udata_front/theme/gouvfr/__init__.py:76
 msgid "Portal for European data"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:72
+#: udata_front/theme/gouvfr/__init__.py:88
 msgid "Data catalog"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:78
+#: udata_front/theme/gouvfr/__init__.py:94
 msgid "Platform's documentation"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:79
+#: udata_front/theme/gouvfr/__init__.py:95
 msgid "Portal's API"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:80
+#: udata_front/theme/gouvfr/__init__.py:96
 msgid "Open data guides"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:87
+#: udata_front/theme/gouvfr/__init__.py:103
 msgid "Licences"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:88
+#: udata_front/theme/gouvfr/__init__.py:104
 msgid "Terms of use"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:89
+#: udata_front/theme/gouvfr/__init__.py:105
 msgid "Tracking and privacy"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:90
+#: udata_front/theme/gouvfr/__init__.py:106
 msgid "Accessibility"
 msgstr ""
 
@@ -170,18 +182,18 @@ msgid "Add to your own website"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:206
-#: udata_front/theme/gouvfr/templates/header.html:122
-#: udata_front/theme/gouvfr/templates/header.html:155
+#: udata_front/theme/gouvfr/templates/header.html:126
+#: udata_front/theme/gouvfr/templates/header.html:159
 msgid "Close"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:295
+#: udata_front/theme/gouvfr/templates/dataset/display.html:307
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:206
 #: udata_front/theme/gouvfr/templates/reuse/display.html:192
 msgid "Embed"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:226
+#: udata_front/theme/gouvfr/templates/dataset/display.html:236
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:209
 msgid "Temporal coverage"
 msgstr ""
@@ -198,7 +210,7 @@ msgstr ""
 msgid "Territory"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:232
+#: udata_front/theme/gouvfr/templates/dataset/display.html:242
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:232
 msgid "Frequency"
 msgstr ""
@@ -210,88 +222,86 @@ msgstr ""
 msgid "License:"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/footer.html:10
+#: udata_front/theme/gouvfr/templates/footer.html:8
 msgid "The Open Data"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/footer.html:20
+#: udata_front/theme/gouvfr/templates/footer.html:18
 msgid "Support"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/footer.html:30
+#: udata_front/theme/gouvfr/templates/footer.html:28
 msgid "Social networks"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/footer.html:52
+#: udata_front/theme/gouvfr/templates/footer.html:50
 msgid "RSS feed"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/footer.html:61
-#: udata_front/theme/gouvfr/templates/footer.html:64
+#: udata_front/theme/gouvfr/templates/footer.html:59
+#: udata_front/theme/gouvfr/templates/footer.html:62
 msgid "Newsletter"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/footer.html:69
+#: udata_front/theme/gouvfr/templates/footer.html:71
+msgid "Go to Etalab’s blog"
+msgstr ""
+
+#: udata_front/theme/gouvfr/templates/footer.html:78
+msgid "A DINUM department"
+msgstr ""
+
+#: udata_front/theme/gouvfr/templates/footer.html:82
+msgid "DINUM website"
+msgstr ""
+
+#: udata_front/theme/gouvfr/templates/footer.html:93
+msgid "Open-source engine"
+msgstr ""
+
+#: udata_front/theme/gouvfr/templates/footer.html:100
+#: udata_front/theme/gouvfr/templates/footer.html:115
+msgid "Deployed version"
+msgstr ""
+
+#: udata_front/theme/gouvfr/templates/footer.html:109
+msgid "Data.gouv.fr extension"
+msgstr ""
+
+#: udata_front/theme/gouvfr/templates/footer.html:147
+msgid "Language selector"
+msgstr ""
+
+#: udata_front/theme/gouvfr/templates/footer.html:176
 msgid ""
 "Unless otherwise stated, all content of this site is availabe under <a "
 "href='{lo_url}'>Open Licence 2.0</a>"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/footer.html:76
-msgid "Go to Etalab’s blog"
-msgstr ""
-
-#: udata_front/theme/gouvfr/templates/footer.html:81
-msgid "A DINUM department"
-msgstr ""
-
-#: udata_front/theme/gouvfr/templates/footer.html:85
-msgid "DINUM website"
-msgstr ""
-
-#: udata_front/theme/gouvfr/templates/footer.html:96
-msgid "Open-source engine"
-msgstr ""
-
-#: udata_front/theme/gouvfr/templates/footer.html:103
-#: udata_front/theme/gouvfr/templates/footer.html:118
-msgid "Deployed version"
-msgstr ""
-
-#: udata_front/theme/gouvfr/templates/footer.html:112
-msgid "Data.gouv.fr extension"
-msgstr ""
-
-#: udata_front/theme/gouvfr/templates/footer.html:133
-#: udata_front/theme/gouvfr/templates/header.html:59
-msgid "Go back to home page"
-msgstr ""
-
-#: udata_front/theme/gouvfr/templates/footer.html:146
-msgid "Language selector"
-msgstr ""
-
 #: udata_front/theme/gouvfr/templates/header.html:24
 msgid ""
 "Internet Explorer 8 and below are not anymore supported.\n"
-"                 Please upgrade or change your browser to access the website."
-"\n"
-"                 <a class=\"fr-link\" href=\"http://browsehappy.com/\">More "
+"                Please upgrade or change your browser to access the website.\n"
+"                <a class=\"fr-link\" href=\"http://browsehappy.com/\">More "
 "information →</a>"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/header.html:42
 #: udata_front/theme/gouvfr/templates/header.html:44
-#: udata_front/theme/gouvfr/templates/header.html:126
-#: udata_front/theme/gouvfr/templates/header.html:132
-#: udata_front/theme/gouvfr/templates/header.html:140
-#: udata_front/theme/gouvfr/templates/header.html:142
+#: udata_front/theme/gouvfr/templates/header.html:130
+#: udata_front/theme/gouvfr/templates/header.html:136
+#: udata_front/theme/gouvfr/templates/header.html:144
+#: udata_front/theme/gouvfr/templates/header.html:146
 msgid "Search for data"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/header.html:51
 #: udata_front/theme/gouvfr/templates/header.html:54
 msgid "Open menu"
+msgstr ""
+
+#: udata_front/theme/gouvfr/templates/header.html:59
+msgid "Go back to home page"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/header.html:89
@@ -302,22 +312,22 @@ msgstr ""
 msgid "Logout"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/header.html:103
-#: udata_front/theme/gouvfr/templates/header.html:106
+#: udata_front/theme/gouvfr/templates/header.html:104
+#: udata_front/theme/gouvfr/templates/header.html:107
 #: udata_front/theme/gouvfr/templates/security/login_user.html:12
 #: udata_front/theme/gouvfr/templates/security/login_user.html:16
 #: udata_front/theme/gouvfr/templates/territories/territory.html:41
 msgid "Log in"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/header.html:111
 #: udata_front/theme/gouvfr/templates/header.html:114
+#: udata_front/theme/gouvfr/templates/header.html:117
 #: udata_front/theme/gouvfr/templates/security/register_user.html:10
 #: udata_front/theme/gouvfr/templates/security/register_user.html:29
 msgid "Sign up"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/header.html:157
+#: udata_front/theme/gouvfr/templates/header.html:161
 msgid "Main Menu"
 msgstr ""
 
@@ -387,7 +397,7 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:347
+#: udata_front/theme/gouvfr/templates/dataset/display.html:359
 #: udata_front/theme/gouvfr/templates/home.html:73
 #: udata_front/theme/gouvfr/templates/reuse/display.html:233
 #: udata_front/theme/gouvfr/templates/site/dashboard.html:25
@@ -412,23 +422,23 @@ msgstr ""
 msgid "Reference datasets"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/home.html:129
-#: udata_front/theme/gouvfr/templates/home.html:183
+#: udata_front/theme/gouvfr/templates/home.html:136
+#: udata_front/theme/gouvfr/templates/home.html:197
 #: udata_front/theme/gouvfr/templates/topic/display.html:68
 msgid "See more"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/home.html:153
+#: udata_front/theme/gouvfr/templates/home.html:160
 msgid "Featured reuses"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/home.html:154
-#: udata_front/theme/gouvfr/templates/home.html:180
+#: udata_front/theme/gouvfr/templates/home.html:161
+#: udata_front/theme/gouvfr/templates/home.html:194
 #: udata_front/theme/gouvfr/templates/topic/display.html:13
 msgid "Latest reuses"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/home.html:162
+#: udata_front/theme/gouvfr/templates/home.html:169
 msgid "Data reuses"
 msgstr ""
 
@@ -447,19 +457,19 @@ msgid "metrics"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/display.html:165
-#: udata_front/theme/gouvfr/templates/organization/display.html:159
-#: udata_front/theme/gouvfr/templates/page.html:54
-#: udata_front/theme/gouvfr/templates/post/display.html:98
+#: udata_front/theme/gouvfr/templates/organization/display.html:163
+#: udata_front/theme/gouvfr/templates/page.html:52
+#: udata_front/theme/gouvfr/templates/post/display.html:93
 #: udata_front/theme/gouvfr/templates/reuse/display.html:120
 msgid "Actions"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/page.html:57
+#: udata_front/theme/gouvfr/templates/page.html:55
 msgid "Suggest a modification"
 msgstr ""
 
 #. This is a call to action.
-#: udata_front/theme/gouvfr/templates/participez/participez.html:18
+#: udata_front/theme/gouvfr/templates/participez/participez.html:22
 #: udata_front/theme/gouvfr/templates/publish-action-modal.html:11
 msgid "Publish a dataset"
 msgstr ""
@@ -470,7 +480,7 @@ msgid "Contribute and add a new dataset to this site catalog."
 msgstr ""
 
 #. This is a call to action.
-#: udata_front/theme/gouvfr/templates/participez/participez.html:22
+#: udata_front/theme/gouvfr/templates/participez/participez.html:30
 #: udata_front/theme/gouvfr/templates/publish-action-modal.html:25
 msgid "Publish a reuse"
 msgstr ""
@@ -517,7 +527,7 @@ msgid "Maintainer"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/api/admin.html:31
-#: udata_front/theme/gouvfr/templates/post/display.html:105
+#: udata_front/theme/gouvfr/templates/post/display.html:100
 #: udata_front/theme/gouvfr/templates/user/base.html:23
 msgid "Edit"
 msgstr ""
@@ -579,15 +589,15 @@ msgstr ""
 msgid "Due to security reasons, the creation of new content is currently disabled."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/card.html:33
+#: udata_front/theme/gouvfr/templates/dataset/card.html:37
 #: udata_front/theme/gouvfr/templates/dataset/search-result.html:43
 msgid "resources"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/card.html:34
+#: udata_front/theme/gouvfr/templates/dataset/card.html:38
 #: udata_front/theme/gouvfr/templates/dataset/search-result.html:45
 #: udata_front/theme/gouvfr/templates/organization/card.html:26
-#: udata_front/theme/gouvfr/templates/organization/producer-summary.html:44
+#: udata_front/theme/gouvfr/templates/organization/producer-summary.html:47
 #: udata_front/theme/gouvfr/templates/reuse/list.html:8
 #: udata_front/theme/gouvfr/templates/topic/reuses.html:8
 msgid "reuses"
@@ -684,145 +694,145 @@ msgstr ""
 msgid "Metadata"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:200
+#: udata_front/theme/gouvfr/templates/dataset/display.html:210
 #: udata_front/theme/gouvfr/templates/reuse/display.html:149
 msgid "Informations"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:203
+#: udata_front/theme/gouvfr/templates/dataset/display.html:213
 msgid "License"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:210
+#: udata_front/theme/gouvfr/templates/dataset/display.html:220
 #: udata_front/theme/gouvfr/templates/reuse/display.html:161
 msgid "ID"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:215
-#: udata_front/theme/gouvfr/templates/dataset/display.html:217
+#: udata_front/theme/gouvfr/templates/dataset/display.html:225
+#: udata_front/theme/gouvfr/templates/dataset/display.html:227
 msgid "Remote source"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:223
+#: udata_front/theme/gouvfr/templates/dataset/display.html:233
 msgid "Temporality"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:235
-#: udata_front/theme/gouvfr/templates/organization/display.html:149
+#: udata_front/theme/gouvfr/templates/dataset/display.html:245
+#: udata_front/theme/gouvfr/templates/organization/display.html:153
 #: udata_front/theme/gouvfr/templates/reuse/display.html:170
 msgid "Creation date"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:239
+#: udata_front/theme/gouvfr/templates/dataset/display.html:249
 msgid "Latest resource update"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:247
+#: udata_front/theme/gouvfr/templates/dataset/display.html:257
 msgid "Geographic dimensions"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:250
+#: udata_front/theme/gouvfr/templates/dataset/display.html:260
 msgid "Territorial coverage granularity"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:254
+#: udata_front/theme/gouvfr/templates/dataset/display.html:264
 msgid "Territorial coverage"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:267
+#: udata_front/theme/gouvfr/templates/dataset/display.html:277
 msgid "Extras"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:283
+#: udata_front/theme/gouvfr/templates/dataset/display.html:293
 #: udata_front/theme/gouvfr/templates/participez/participez.html:5
 #: udata_front/theme/gouvfr/templates/reuse/display.html:180
 msgid "Participate"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:286
-#: udata_front/theme/gouvfr/templates/dataset/display.html:463
+#: udata_front/theme/gouvfr/templates/dataset/display.html:296
+#: udata_front/theme/gouvfr/templates/dataset/display.html:475
 #: udata_front/theme/gouvfr/templates/reuse/display.html:183
 msgid "Add a reuse"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:291
+#: udata_front/theme/gouvfr/templates/dataset/display.html:303
 msgid "Contact the producer"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:297
+#: udata_front/theme/gouvfr/templates/dataset/display.html:309
 #: udata_front/theme/gouvfr/templates/dataset/resource/card.html:97
 #: udata_front/theme/gouvfr/templates/reuse/display.html:194
 msgid "Permalink"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:311
+#: udata_front/theme/gouvfr/templates/dataset/display.html:323
 #: udata_front/theme/gouvfr/templates/macros/integrate.html:11
 #: udata_front/theme/gouvfr/templates/reuse/display.html:208
 msgid "Copy this"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:322
+#: udata_front/theme/gouvfr/templates/dataset/display.html:334
 #: udata_front/theme/gouvfr/templates/reuse/display.html:219
 msgid "Summary"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:326
-#: udata_front/theme/gouvfr/templates/dataset/display.html:357
+#: udata_front/theme/gouvfr/templates/dataset/display.html:338
+#: udata_front/theme/gouvfr/templates/dataset/display.html:369
 #: udata_front/theme/gouvfr/templates/organization/display.html:84
 #: udata_front/theme/gouvfr/templates/reuse/display.html:223
 #: udata_front/theme/gouvfr/templates/reuse/display.html:248
 msgid "Description"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:331
-#: udata_front/theme/gouvfr/templates/dataset/display.html:366
+#: udata_front/theme/gouvfr/templates/dataset/display.html:343
+#: udata_front/theme/gouvfr/templates/dataset/display.html:378
 msgid "Files"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:336
-#: udata_front/theme/gouvfr/templates/dataset/display.html:412
-#: udata_front/theme/gouvfr/templates/dataset/display.html:444
+#: udata_front/theme/gouvfr/templates/dataset/display.html:348
+#: udata_front/theme/gouvfr/templates/dataset/display.html:424
+#: udata_front/theme/gouvfr/templates/dataset/display.html:456
 msgid "Community resources"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:396
+#: udata_front/theme/gouvfr/templates/dataset/display.html:408
 #, python-format
 msgid "See the %(nb)d resources of type %(type)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:401
+#: udata_front/theme/gouvfr/templates/dataset/display.html:413
 msgid "No resources"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:419
+#: udata_front/theme/gouvfr/templates/dataset/display.html:431
 msgid "Publish a resource"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:427
+#: udata_front/theme/gouvfr/templates/dataset/display.html:439
 msgid ""
 "You have built a more comprehensive database than those presented here? This "
 "is the time to share it!"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:436
+#: udata_front/theme/gouvfr/templates/dataset/display.html:448
 msgid ""
 "These resources are published by the community and the producer isn't "
 "responsible for them."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:468
+#: udata_front/theme/gouvfr/templates/dataset/display.html:480
 msgid "Explore the reuses of this dataset."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:469
+#: udata_front/theme/gouvfr/templates/dataset/display.html:481
 msgid "Did you use this data ? Reference your work and increase your visibility."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:486
+#: udata_front/theme/gouvfr/templates/dataset/display.html:498
 msgid "Discussion between the organization and the community about this dataset."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:488
+#: udata_front/theme/gouvfr/templates/dataset/display.html:500
 msgid "Discussion between the owner and the community about this dataset."
 msgstr ""
 
@@ -835,7 +845,7 @@ msgid "Followers"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/followers.html:13
-#: udata_front/theme/gouvfr/templates/organization/search-result.html:33
+#: udata_front/theme/gouvfr/templates/organization/search-result.html:38
 #: udata_front/theme/gouvfr/templates/user/base.html:72
 #: udata_front/theme/gouvfr/templates/user/followers.html:12
 #, python-format
@@ -860,7 +870,7 @@ msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/list.html:16
 #: udata_front/theme/gouvfr/templates/organization/card.html:23
-#: udata_front/theme/gouvfr/templates/organization/producer-summary.html:38
+#: udata_front/theme/gouvfr/templates/organization/producer-summary.html:42
 #: udata_front/theme/gouvfr/templates/reuse/card.html:18
 #: udata_front/theme/gouvfr/templates/topic/datasets.html:8
 msgid "datasets"
@@ -909,7 +919,7 @@ msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/list.html:71
 #: udata_front/theme/gouvfr/templates/organization/list.html:56
-#: udata_front/theme/gouvfr/templates/reuse/list.html:100
+#: udata_front/theme/gouvfr/templates/reuse/list.html:103
 #, python-format
 msgid "%(result)s results"
 msgstr ""
@@ -1356,32 +1366,32 @@ msgstr ""
 msgid "Modify organization"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:107
+#: udata_front/theme/gouvfr/templates/organization/display.html:111
 #, python-format
 msgid "See %(count)s datasets"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:126
+#: udata_front/theme/gouvfr/templates/organization/display.html:130
 msgid "Members"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:142
+#: udata_front/theme/gouvfr/templates/organization/display.html:146
 msgid "Technical details"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:153
+#: udata_front/theme/gouvfr/templates/organization/display.html:157
 msgid "Modification date"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:167
+#: udata_front/theme/gouvfr/templates/organization/display.html:171
 msgid "Modify information"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:176
+#: udata_front/theme/gouvfr/templates/organization/display.html:180
 msgid "Download list of datasets as csv file"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:190
+#: udata_front/theme/gouvfr/templates/organization/display.html:194
 msgid "Pending request to join this organization"
 msgstr ""
 
@@ -1409,11 +1419,11 @@ msgstr ""
 msgid "Search among %(count)s organizations on %(site)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/search-result.html:22
+#: udata_front/theme/gouvfr/templates/organization/search-result.html:27
 msgid "Number of datasets"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/search-result.html:23
+#: udata_front/theme/gouvfr/templates/organization/search-result.html:28
 #: udata_front/theme/gouvfr/templates/user/base.html:84
 #, python-format
 msgid "%(num)d dataset"
@@ -1421,11 +1431,11 @@ msgid_plural "%(num)d datasets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/organization/search-result.html:27
+#: udata_front/theme/gouvfr/templates/organization/search-result.html:32
 msgid "Number of reuses by the organization"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/search-result.html:28
+#: udata_front/theme/gouvfr/templates/organization/search-result.html:33
 #: udata_front/theme/gouvfr/templates/user/base.html:90
 #, python-format
 msgid "%(num)d reuse"
@@ -1433,15 +1443,15 @@ msgid_plural "%(num)d reuses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/organization/search-result.html:32
+#: udata_front/theme/gouvfr/templates/organization/search-result.html:37
 msgid "Number of followers"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/search-result.html:36
+#: udata_front/theme/gouvfr/templates/organization/search-result.html:41
 msgid "Number of members"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/search-result.html:37
+#: udata_front/theme/gouvfr/templates/organization/search-result.html:42
 #, python-format
 msgid "%(num)d members"
 msgid_plural "%(num)d members"
@@ -1467,15 +1477,15 @@ msgstr ""
 msgid "This post has been deleted. This will be permanent in the next 24 hours"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/post/display.html:122
+#: udata_front/theme/gouvfr/templates/post/display.html:117
 msgid "Previous post"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/post/display.html:128
+#: udata_front/theme/gouvfr/templates/post/display.html:123
 msgid "All posts"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/post/display.html:137
+#: udata_front/theme/gouvfr/templates/post/display.html:132
 msgid "Next post"
 msgstr ""
 
@@ -1656,7 +1666,7 @@ msgstr ""
 msgid "Search in datasets"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/list.html:84
+#: udata_front/theme/gouvfr/templates/reuse/list.html:86
 msgid "All"
 msgstr ""
 

--- a/udata_front/theme/gouvfr/translations/gouvfr.pot
+++ b/udata_front/theme/gouvfr/translations/gouvfr.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: udata-front 2.0.3.dev0\n"
 "Report-Msgid-Bugs-To: data.gouv@data.gouv.fr\n"
-"POT-Creation-Date: 2022-06-07 14:53+0200\n"
-"PO-Revision-Date: 2022-06-07 14:53+0200\n"
+"POT-Creation-Date: 2022-06-13 09:49+0200\n"
+"PO-Revision-Date: 2022-06-13 09:50+0200\n"
 "Last-Translator: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
 "Language: en\n"
 "Language-Team: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
@@ -95,7 +95,7 @@ msgid "News"
 msgstr ""
 
 #: udata_front/theme/gouvfr/__init__.py:50
-msgid "Starting on data.gouv.fr"
+msgid "Getting started on data.gouv.fr"
 msgstr ""
 
 #: udata_front/theme/gouvfr/__init__.py:52


### PR DESCRIPTION
This PR add new menu items as nested items.

Nested items are shown in a collapsible menu. 
Ids and aria-* are used to make it accessible.

Previous jinja call to check if an item is the current endpoint is now an helper called `is_current_endpoint`.
There is a new jinja helper to check a match for both the endpoint and the corresponding args called `is_current_page`.
The new one is used for nested items.

Close https://github.com/etalab/data.gouv.fr/issues/846
Close https://github.com/etalab/data.gouv.fr/issues/479