### PR TITLE
Update SVG optimisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Add accessibility compliance status in footer [#114](https://github.com/etalab/udata-front/pull/114)
+- Fix SVG display issue [#116](https://github.com/etalab/udata-front/pull/116)
 
 ## 2.0.3 (2022-06-03)
 

--- a/svgo.config.js
+++ b/svgo.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  plugins: [
+    {
+      name: 'preset-default',
+      params: {
+        overrides: {
+          removeViewBox: false,
+        },
+      },
+    },
+  ],
+};


### PR DESCRIPTION
Parcel updates bring SVG optimisation with conflict with our SVGs.

SVGO removes `viewBow` attributes if it's the same as width and height attributes.

We disable this specific optimisation rule with this PR.

Another solution would be to edit current and future SVG files to remove `width` and `height` attributes.
This would allow us to gain 20 characters per file but we would have to do it for each SVG and file update.