### PR TITLE
Update pages slug and change header order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Add new menu items [#113](https://github.com/etalab/udata-front/pull/113)
+- Add new menu items and change edito pages slug [#113](https://github.com/etalab/udata-front/pull/113) [#120](https://github.com/etalab/udata-front/pull/120)
 - Replace news by release notes in footer [#117](https://github.com/etalab/udata-front/pull/117)
 - Use DSFR container and remove custom ones [#111](https://github.com/etalab/udata-front/pull/111)
 

--- a/udata_front/theme/gouvfr/__init__.py
+++ b/udata_front/theme/gouvfr/__init__.py
@@ -46,12 +46,11 @@ gouvfr_menu = nav.Bar('gouvfr_menu', [
     nav.Item(_('Data'), 'datasets.list'),
     nav.Item(_('Reuses'), 'reuses.list'),
     nav.Item(_('Organizations'), 'organizations.list'),
-    nav.Item(_('News'), 'posts.list'),
     nav.Item(_('Getting started on data.gouv.fr'), None, items=[
         nav.Item(
             _('What is data.gouv.fr?'),
             'gouvfr.show_page',
-            args={'slug': 'about/ressources'}
+            args={'slug': 'about/a-propos_data-gouv'}
         ),
         nav.Item(
             _('How to publish data ?'),
@@ -64,13 +63,14 @@ gouvfr_menu = nav.Bar('gouvfr_menu', [
             args={'slug': 'onboarding/reutilisateurs'}
         ),
     ]),
+    nav.Item(_('News'), 'posts.list'),
     nav.Item(_('Contact us'), None, url='https://support.data.gouv.fr/'),
 ])
 
 theme.menu(gouvfr_menu)
 
 opendata_links = [
-    nav.Item(_('Featured topics'), 'gouvfr.show_page', args={'slug': 'donnees-cles-par-sujet'}),
+    nav.Item(_('Featured topics'), 'gouvfr.show_page', args={'slug': 'thematiques-a-la-une'}),
     nav.Item(_('Reference Data'), 'gouvfr.show_page', args={'slug': 'spd/reference'}),
     nav.Item(_('Portal for European data'), None, url='https://data.europa.eu'),
 ]

--- a/udata_front/theme/gouvfr/templates/home.html
+++ b/udata_front/theme/gouvfr/templates/home.html
@@ -35,7 +35,7 @@
                     </a>
                     <div class="fr-grid-row justify-center fr-mt-2w">
                         <a
-                            href="{{ url_for('gouvfr.show_page', slug='donnees-cles-par-sujet') }}"
+                            href="{{ url_for('gouvfr.show_page', slug='thematiques-a-la-une') }}"
                             class="fr-btn fr-btn--secondary fr-icon-arrow-right-s-line fr-btn--icon-right"
                         >
                             {{ _('All featured topics') }}


### PR DESCRIPTION
Follows [this discussion](https://mattermost.incubateur.net/betagouv/pl/pt1fusqqwt8f3euxb9escgpn6a)

Move `news` on the right of `getting started` in header
Replace `donnees-cles-par-sujet` by `thematiques-a-la-une` (home and footer)
Replace `about/ressources` by `about/a-propos_data-gouv` (header)