### PR TITLE
Feat/update cards after feedbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Update search results [#136](https://github.com/etalab/udata-front/pull/136) 
 
 ## 2.0.6 (2022-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Update search results [#136](https://github.com/etalab/udata-front/pull/136) 
+- Iterate on search results and cards [#136](https://github.com/etalab/udata-front/pull/136) 
 
 ## 2.0.6 (2022-07-08)
 

--- a/theme/js/components/dataset/search-result.vue
+++ b/theme/js/components/dataset/search-result.vue
@@ -34,13 +34,13 @@
               {{ $t('Private') }}
             </span>
           </h4>
-          <p class="fr-m-0 not-enlarged" v-if="organization || owner">
+          <span class="not-enlarged" v-if="organization || owner">
             {{ $t('From') }} 
             <a v-if="organization" :href="organization.page">
                 <OrganizationNameWithCertificate :organization="organization" />
             </a>
             <template v-if="owner">{{ownerName}}</template>
-          </p>
+          </span>
           <p class="fr-mt-1w fr-mb-2w fr-hidden fr-unhidden-sm">
             {{ $filters.excerpt(description, 160) }}
           </p>

--- a/udata_front/tests/views/test_organization.py
+++ b/udata_front/tests/views/test_organization.py
@@ -139,20 +139,20 @@ class OrganizationBlueprintTest(GouvfrFrontTestCase):
     def test_render_display_with_paginated_datasets(self):
         '''It should render the organization page with paginated datasets'''
         organization = OrganizationFactory()
-        datasets_len = OrganizationDetailView.page_size + 1
+        datasets_len = OrganizationDetailView.dataset_page_size + 1
         for _ in range(datasets_len):
             VisibleDatasetFactory(organization=organization)
         response = self.get(url_for('organizations.show', org=organization))
 
         self.assert200(response)
         rendered_datasets = self.get_context_variable('datasets')
-        self.assertEqual(len(rendered_datasets), OrganizationDetailView.page_size)
+        self.assertEqual(len(rendered_datasets), OrganizationDetailView.dataset_page_size)
 
     def test_render_display_with_paginated_datasets_on_second_page(self):
         '''It should render the organization page with paginated datasets'''
         organization = OrganizationFactory()
         second_page_len = 1
-        datasets_len = OrganizationDetailView.page_size + second_page_len
+        datasets_len = OrganizationDetailView.dataset_page_size + second_page_len
         for _ in range(datasets_len):
             VisibleDatasetFactory(organization=organization)
         response = self.get(url_for('organizations.show', org=organization, datasets_page=2))
@@ -201,19 +201,19 @@ class OrganizationBlueprintTest(GouvfrFrontTestCase):
     def test_render_display_with_paginated_reuses(self):
         '''It should render the organization page with paginated reuses'''
         organization = OrganizationFactory()
-        reuses_len = OrganizationDetailView.page_size + 1
+        reuses_len = OrganizationDetailView.reuse_page_size + 1
         for _ in range(reuses_len):
             VisibleReuseFactory(organization=organization)
         response = self.get(url_for('organizations.show', org=organization))
 
         self.assert200(response)
         rendered_reuses = self.get_context_variable('reuses')
-        self.assertEqual(len(rendered_reuses), OrganizationDetailView.page_size)
+        self.assertEqual(len(rendered_reuses), OrganizationDetailView.reuse_page_size)
 
     def test_render_display_with_paginated_reuses_on_second_page(self):
         '''It should render the organization page with paginated datasets'''
         second_page_len = 1
-        reuses_len = OrganizationDetailView.page_size + second_page_len
+        reuses_len = OrganizationDetailView.reuse_page_size + second_page_len
         organization = OrganizationFactory()
         for _ in range(reuses_len):
             VisibleReuseFactory(organization=organization)

--- a/udata_front/theme/gouvfr/templates/dataset/search-result.html
+++ b/udata_front/theme/gouvfr/templates/dataset/search-result.html
@@ -40,7 +40,7 @@
                 {% if dataset.private %}<span class="badge grey-300 fr-ml-1w">{{ _('Private') }}</span>{% endif %}
             </h4>
             {% if dataset.organization or dataset.owner %}
-            <p class="fr-m-0 not-enlarged">
+            <span class="not-enlarged">
                 {{ _('From') }}
                 {% if dataset.organization %}
                 <a href="{{ url_for('organizations.show', org=dataset.organization) }}">
@@ -49,7 +49,7 @@
                 {% elif dataset.owner %}
                 {{owner_name(dataset)}}
                 {% endif %}
-            </p>
+            </span>
             {% endif %}
             <p class="fr-mt-1w fr-mb-2w fr-hidden fr-unhidden-sm">
                 {{ dataset.description|mdstrip(300) }}

--- a/udata_front/theme/gouvfr/templates/organization/card.html
+++ b/udata_front/theme/gouvfr/templates/organization/card.html
@@ -16,18 +16,18 @@
         <ul class="fr-tags-group fr-mt-auto">
             <li class="not-enlarged">
                 <a
-                        href="{{ url_for('datasets.list', organization=organization.id) }}"
-                        class="fr-tag"
-                    >
-                    {{ ngettext('Dataset: <strong class="fr-ml-1v">%(num)d</strong>', 'Datasets: <strong class="fr-ml-1v">%(num)d</strong>', organization.metrics.datasets or 0) }}
+                    href="{{ url_for('datasets.list', organization=organization.id) }}"
+                    class="fr-tag"
+                >
+                    {{ ngettext('<strong class="fr-mr-1v">%(num)d</strong> dataset', '<strong class="fr-mr-1v">%(num)d</strong> datasets', organization.metrics.datasets or 0) }}
                 </a>
             </li>
             <li class="not-enlarged">
                 <a
-                        href="{{ url_for('organizations.show', org=organization, _anchor='organization-reuses') }}"
-                        class="fr-tag"
-                    >
-                    {{ ngettext('Reuse: <strong class="fr-ml-1v">%(num)d</strong>', 'Reuses: <strong class="fr-ml-1v">%(num)d</strong>', organization.metrics.reuses or 0) }}
+                    href="{{ url_for('organizations.show', org=organization, _anchor='organization-reuses') }}"
+                    class="fr-tag"
+                >
+                    {{ ngettext('<strong class="fr-mr-1v">%(num)d</strong> reuse', '<strong class="fr-mr-1v">%(num)d</strong> reuses', organization.metrics.reuses or 0) }}
                 </a>
             </li>
         </ul>

--- a/udata_front/theme/gouvfr/templates/participez/participez.html
+++ b/udata_front/theme/gouvfr/templates/participez/participez.html
@@ -16,7 +16,7 @@
             <div class="fr-col-12 fr-col-sm-6 fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
                 <div class="fr-col-12 fr-col-lg-6">
                     <a
-                        href="{{ config.GUIDES_DATASET_URL }}"
+                        href="{{ url_for('admin.index', path='dataset/new/') }}"
                         class="fr-btn fr-btn--secondary fr-btn--secondary-white fr-icon-arrow-right-s-line fr-btn--icon-right"
                     >
                         {{ _('Publish a dataset') }}
@@ -24,7 +24,7 @@
                 </div>
                 <div class="fr-col-12 fr-col-lg-6">
                     <a
-                        href="{{ config.GUIDES_REUSE_URL }}"
+                        href="{{ url_for('admin.index', path='reuse/new/') }}"
                         class="fr-btn fr-btn--secondary fr-btn--secondary-white fr-icon-arrow-right-s-line fr-btn--icon-right"
                     >
                         {{ _('Publish a reuse') }}

--- a/udata_front/theme/gouvfr/templates/reuse/display.html
+++ b/udata_front/theme/gouvfr/templates/reuse/display.html
@@ -253,7 +253,7 @@
             </read-more>
         </div>
     </section>
-    <section class="reuse-sources fr-container fr-my-3w">
+    <section class="reuse-sources fr-container fr-my-7w">
         <div class="fr-grid-row">
             <h2 id="used-datasets" class="fr-h2">
                 {{ _('Used datasets') }}
@@ -262,8 +262,8 @@
         </div>
     <ul class="fr-grid-row fr-grid-row--gutters">
         {% for dataset in visible_datasets %}
-        <li class="fr-col-md-6 fr-col-12">
-            {% include theme('dataset/card.html') %}
+        <li class="fr-col-12">
+            {% include theme('dataset/search-result.html') %}
         </li>
         {% endfor %}
     </ul>

--- a/udata_front/theme/gouvfr/templates/reuse/list.html
+++ b/udata_front/theme/gouvfr/templates/reuse/list.html
@@ -47,7 +47,7 @@
 ] %}
 
 {% block main_content %}
-<section class="fr-container">
+<section class="fr-container fr-py-2w">
     <h1 class="fr-mb-1w">{{_('Reuses')}}</h1>
     <div class="fr-grid-row fr-grid-row--middle justify-between">
         <div>{{_('Search among %(count)s reuses on %(site)s', count=current_site.metrics['reuses']|format_number, site=current_site.title)}}</div>

--- a/udata_front/views/dataset.py
+++ b/udata_front/views/dataset.py
@@ -78,7 +78,7 @@ class ProtectedDatasetView(DatasetView):
 @blueprint.route('/<dataset:dataset>/', endpoint='show')
 class DatasetDetailView(DatasetView, DetailView):
     template_name = 'dataset/display.html'
-    page_size = 4
+    page_size = 8
 
     def dispatch_request(self, *args, **kwargs):
         return super(DatasetDetailView, self).dispatch_request(*args, **kwargs)

--- a/udata_front/views/dataset.py
+++ b/udata_front/views/dataset.py
@@ -78,7 +78,7 @@ class ProtectedDatasetView(DatasetView):
 @blueprint.route('/<dataset:dataset>/', endpoint='show')
 class DatasetDetailView(DatasetView, DetailView):
     template_name = 'dataset/display.html'
-    page_size = 8
+    reuse_page_size = 8
 
     def dispatch_request(self, *args, **kwargs):
         return super(DatasetDetailView, self).dispatch_request(*args, **kwargs)
@@ -93,7 +93,7 @@ class DatasetDetailView(DatasetView, DetailView):
                 abort(404)
             elif self.dataset.deleted:
                 abort(410)
-        context['reuses'] = reuses.paginate(params_reuses_page, self.page_size)
+        context['reuses'] = reuses.paginate(params_reuses_page, self.reuse_page_size)
         context['total_reuses'] = len(reuses)
         context['can_edit'] = DatasetEditPermission(self.dataset)
         context['can_edit_resource'] = ResourceEditPermission

--- a/udata_front/views/organization.py
+++ b/udata_front/views/organization.py
@@ -64,7 +64,8 @@ class ProtectedOrgView(OrgView):
 @blueprint.route('/<org:org>/', endpoint='show')
 class OrganizationDetailView(OrgView, DetailView):
     template_name = 'organization/display.html'
-    page_size = 4
+    dataset_page_size = 4
+    reuse_page_size = 8
 
     def get_context(self):
         context = super(OrganizationDetailView, self).get_context()
@@ -94,8 +95,8 @@ class OrganizationDetailView(OrgView, DetailView):
             reuses = reuses.visible()
 
         context.update({
-            'reuses': reuses.paginate(params_reuses_page, self.page_size),
-            'datasets': datasets.paginate(params_datasets_page, self.page_size),
+            'reuses': reuses.paginate(params_reuses_page, self.reuse_page_size),
+            'datasets': datasets.paginate(params_datasets_page, self.dataset_page_size),
             'total_datasets': len(datasets),
             'total_reuses': len(reuses),
             'followers': followers,


### PR DESCRIPTION
I updated search results based on mattermost feedbacks : 
- [x] text changes for tags on organization card
- [x] 2 lines of reuses on dataset and organization pages
- [x] new dataset card on reuses pages
- [x] Add admin link to "participez"

Close https://github.com/etalab/data.gouv.fr/issues/886