### PR TITLE
Compute z-index in search result template

### DIFF
--- a/udata_front/theme/gouvfr/templates/dataset/list.html
+++ b/udata_front/theme/gouvfr/templates/dataset/list.html
@@ -96,7 +96,8 @@
         <ul class="search-results fr-mt-3v">
             {% for dataset in datasets %}
             <li>
-                {% with z_index = "z-index: {index:d}".format(index=(datasets.page_size - loop.index0)) %}
+                {# FIXME: remove with loop when upgrading jinja. See https://github.com/pallets/jinja/pull/1242 #}
+                {% with loop_ = loop %}
                 {% include theme('dataset/search-result.html') %}
                 {% endwith %}
             </li>

--- a/udata_front/theme/gouvfr/templates/dataset/search-result.html
+++ b/udata_front/theme/gouvfr/templates/dataset/search-result.html
@@ -1,7 +1,7 @@
 {% cache cache_duration, 'dataset-search-result', dataset.id|string, g.lang_code %}
 {% from theme('macros/organization_name_with_certificate.html') import organization_name_with_certificate %}
 {% from theme('macros/quality_score_with_tooltip.html') import quality_score_with_tooltip %}
-<article class="fr-pt-5v fr-pb-6v fr-px-1w border-bottom border-default-grey fr-enlarge-link" style="{{z_index}}">
+<article class="fr-pt-5v fr-pb-6v fr-px-1w border-bottom border-default-grey fr-enlarge-link" style="z-index: {{loop.length - loop.index0}}">
     <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
         <div class="fr-col-auto">
             <div class="logo">

--- a/udata_front/theme/gouvfr/templates/organization/display.html
+++ b/udata_front/theme/gouvfr/templates/organization/display.html
@@ -94,7 +94,10 @@
 <section id="organization-datasets" class="fr-py-9v fr-container">
     <h2>{{ _('Datasets') }}<sup>{{ total_datasets }}</sup></h2>
     {% for dataset in datasets %}
+        {# FIXME: remove with loop when upgrading jinja. See https://github.com/pallets/jinja/pull/1242 #}
+        {% with loop_ = loop %}
         {% include theme('dataset/search-result.html') %}
+        {% endwith %}
     {% endfor %}
     <div class="fr-my-2w">
         {{ paginator(datasets, arg_name='datasets_page', url='#organization-datasets') }}

--- a/udata_front/theme/gouvfr/templates/page.html
+++ b/udata_front/theme/gouvfr/templates/page.html
@@ -25,7 +25,10 @@
     <div class="fr-grid-row fr-grid-row--gutters">
         <div class="fr-col-12">
             {% for dataset in datasets %}
+                {# FIXME: remove with loop when upgrading jinja. See https://github.com/pallets/jinja/pull/1242 #}
+                {% with loop_ = loop %}
                 {% include theme('dataset/search-result.html') %}
+                {% endwith %}
             {% endfor %}
         </div>
     </div>

--- a/udata_front/theme/gouvfr/templates/post/display.html
+++ b/udata_front/theme/gouvfr/templates/post/display.html
@@ -65,7 +65,10 @@
     <div class="fr-grid-row">
         <div class="fr-col-12">
             {% for dataset in post.datasets %}
+                {# FIXME: remove with loop when upgrading jinja. See https://github.com/pallets/jinja/pull/1242 #}
+                {% with loop_ = loop %}
                 {% include theme('dataset/search-result.html') %}
+                {% endwith %}
             {% endfor %}
         </div>
     </div>

--- a/udata_front/theme/gouvfr/templates/reuse/display.html
+++ b/udata_front/theme/gouvfr/templates/reuse/display.html
@@ -263,7 +263,10 @@
     <ul class="fr-grid-row fr-grid-row--gutters">
         {% for dataset in visible_datasets %}
         <li class="fr-col-12">
+            {# FIXME: remove with loop when upgrading jinja. See https://github.com/pallets/jinja/pull/1242 #}
+            {% with loop_ = loop %}
             {% include theme('dataset/search-result.html') %}
+            {% endwith %}        
         </li>
         {% endfor %}
     </ul>

--- a/udata_front/theme/gouvfr/templates/topic/browse.html
+++ b/udata_front/theme/gouvfr/templates/topic/browse.html
@@ -24,7 +24,10 @@
         {% if datasets %}
         <ul class="search-results">
             {% for dataset in datasets %}
-            {% include theme('dataset/search-result.html') %}
+                {# FIXME: remove with loop when upgrading jinja. See https://github.com/pallets/jinja/pull/1242 #}
+                {% with loop_ = loop %}
+                {% include theme('dataset/search-result.html') %}
+                {% endwith %}
             {% endfor %}
         </ul>
             {% if datasets.has_next %}

--- a/udata_front/theme/gouvfr/templates/topic/datasets.html
+++ b/udata_front/theme/gouvfr/templates/topic/datasets.html
@@ -32,7 +32,10 @@
 
                 <ul class="search-results">
                     {% for dataset in datasets %}
+                        {# FIXME: remove with loop when upgrading jinja. See https://github.com/pallets/jinja/pull/1242 #}
+                        {% with loop_ = loop %}
                         {% include theme('dataset/search-result.html') %}
+                        {% endwith %}
                     {% endfor %}
                 </ul>
 


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/910

It computes `z-index` value directly in the search result template.

Sadly, when using the `dataset/search-result.html` template, we need to make a hack to make the jinja `loop` variable available.
See https://github.com/pallets/jinja/pull/1242.

At least this doesn't fail silently if someone tries to use this template without the `loop` var in the scope.