### PR TITLE
Increment z-index to prevent the last elem bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Fix discussions text wrap [#145](https://github.com/etalab/udata-front/pull/145)
 - Update Venti buttons [#146](https://github.com/etalab/udata-front/pull/146)
 - :warning: @blue-470 and @blue-500 are removed
-- Fix z-index value in dataset search-result template [#153](https://github.com/etalab/udata-front/pull/153)
+- Fix z-index value in dataset search-result template [#153](https://github.com/etalab/udata-front/pull/153) [#155](https://github.com/etalab/udata-front/pull/155)
 - Fix RGAA criterion 8.2 [#147](https://github.com/etalab/udata-front/pull/147)
 
 ## 2.0.10 (2022-08-11)

--- a/udata_front/theme/gouvfr/templates/dataset/search-result.html
+++ b/udata_front/theme/gouvfr/templates/dataset/search-result.html
@@ -1,7 +1,7 @@
 {% cache cache_duration, 'dataset-search-result', dataset.id|string, g.lang_code %}
 {% from theme('macros/organization_name_with_certificate.html') import organization_name_with_certificate %}
 {% from theme('macros/quality_score_with_tooltip.html') import quality_score_with_tooltip %}
-<article class="fr-pt-5v fr-pb-6v fr-px-1w border-bottom border-default-grey fr-enlarge-link" style="z-index: {{loop.length - loop.index0}}">
+<article class="fr-pt-5v fr-pb-6v fr-px-1w border-bottom border-default-grey fr-enlarge-link" style="z-index: {{loop.length - loop.index0 + 1}}">
     <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
         <div class="fr-col-auto">
             <div class="logo">


### PR DESCRIPTION
Follows https://github.com/etalab/udata-front/pull/153

Last elem in datasets lists (ex on organization page) was z-index = 1, similar to pagination z-index.
It lead to pagination showing on top of the last quality score tooltip.

It would be a better solution to create a dedicated component (to hide the hack made in https://github.com/etalab/udata-front/pull/153 as well), and this can be done in a second iteration. See: https://github.com/etalab/data.gouv.fr/issues/918