### PR TITLE
Feat/use harvest metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Display and use new harvest metadata [#168](https://github.com/etalab/udata-front/pull/168)
 
 ## 2.0.13 (2022-11-02)
 

--- a/theme/js/api/resources.js
+++ b/theme/js/api/resources.js
@@ -5,10 +5,12 @@ import {api, apiv2} from "../plugins/api";
  * @property {Object} created_at
  * @property {Object} description
  * @property {Object} extras
+ * @property {Object} harvest
  * @property {number} filesize
  * @property {string} filetype
  * @property {string} format
  * @property {string} last_modified
+ * @property {string} last_update
  * @property {string} preview_url
  * @property {string} published
  * @property {Object} schema

--- a/theme/js/components/dataset/search-result.vue
+++ b/theme/js/components/dataset/search-result.vue
@@ -105,12 +105,10 @@
               </span>
               <QualityScore :score="quality.score"/>
           </Tooltip>
-          <template v-if="!externalSource">
-            <span class="fr-hidden inline-sm">
-              &mdash;
-            </span>
-            {{ $t('Updated on {date}', {date: $filters.formatDate(last_modified)}) }}
-          </template>
+          <span class="fr-hidden inline-sm">
+            &mdash;
+          </span>
+          {{ $t('Updated on {date}', {date: $filters.formatDate(last_update)}) }}
         </p>
       </div>
       <ul class="fr-hidden fr-unhidden-sm fr-hidden-md fr-unhidden-lg fr-col-auto fr-tags-group fr-grid-row--bottom self-center flex-direction-column">
@@ -142,7 +140,6 @@ import { defineComponent, computed, ComputedRef } from "vue";
 import lock from "bundle-text:svg/private.svg";
 import useLicense from "../../composables/useLicense";
 import useOwnerName from "../../composables/useOwnerName";
-import useExternalSource from "../../composables/useExternalSource";
 import Avatar from "../discussions/avatar.vue";
 import OrganizationNameWithCertificate from "../organization/organization-name-with-certificate.vue";
 import Placeholder from "../utils/placeholder.vue";
@@ -166,10 +163,7 @@ export default defineComponent({
       type: String,
       required: true,
     },
-    extras: {
-      type: Object,
-    },
-    last_modified: {
+    last_update: {
       type: Date,
       required: true,
     },
@@ -213,9 +207,7 @@ export default defineComponent({
     });
     const ownerName = useOwnerName(owned);
     const license = useLicense(props.license);
-    const externalSource = useExternalSource(props.extras);
     return {
-      externalSource,
       license,
       lock,
       ownerName,

--- a/theme/js/composables/useExternalSource.js
+++ b/theme/js/composables/useExternalSource.js
@@ -1,8 +1,0 @@
-/**
- * 
- * @param {Object} extras 
- * @returns {String | undefined}
- */
-export default function useExternalSource(extras) {
-    return extras?.remote_url;
-}

--- a/udata_front/frontend/helpers.py
+++ b/udata_front/frontend/helpers.py
@@ -211,7 +211,7 @@ def owner_name_acronym(obj):
 
 @front.app_template_global()
 def external_source(dataset):
-    return dataset.extras['remote_url'] if 'remote_url' in dataset.extras else None
+    return dataset.harvest.remote_url if dataset.harvest else None
 
 
 @front.app_template_global()

--- a/udata_front/theme/gouvfr/templates/dataset/display.html
+++ b/udata_front/theme/gouvfr/templates/dataset/display.html
@@ -286,7 +286,22 @@
                                 {% endfor %}
                             </dl>
                         </details>
-                {% endif %}
+                    {% endif %}
+                    {% if dataset.harvest %}
+                        <details>
+                            <summary class="subtitle fr-mb-0">{{ _('Harvest') }}</summary>
+                            <dl class="fr-my-0 fr-grid-row fr-grid-row--gutters">
+                                {% for harvest_extra_name, harvest_extra_value in dataset.harvest._data.items() %}
+                                {% if harvest_extra_value != None %}
+                                <div class="fr-col-12 fr-col-sm-4 fr-col-md-6 fr-col-lg-4">
+                                    <dt class="fr-text--sm fr-mb-0 text-mention-grey">{{ harvest_extra_name }}</dt>
+                                    <dd class="fr-text--sm fr-ml-0 fr-mb-2w">{{ harvest_extra_value }}</dd>
+                                </div>
+                                {% endif %}
+                                {% endfor %}
+                            </dl>
+                        </details>
+                    {% endif %}
                 </div>
                 <div id="tab-actions-panel" class="fr-tabs__panel" role="tabpanel"
                     aria-labelledby="tab-actions" tabindex="0">

--- a/udata_front/theme/gouvfr/templates/dataset/display.html
+++ b/udata_front/theme/gouvfr/templates/dataset/display.html
@@ -220,10 +220,10 @@
                                 <dd class="fr-text--sm fr-ml-0 fr-mb-2w">
                                     {{dataset.id}}
                                 </dd>
-                                {% if external_source %}
+                                {% if external_source(dataset) %}
                                 <dt class="fr-text--sm fr-mb-0 text-mention-grey">{{ _('Remote source') }}</dt>
                                 <dd class="fr-text--sm fr-ml-0 fr-mb-2w">
-                                    <a rel="nofollow" href="{{ external_source }}">{{ _('Remote source') }}</a>
+                                    <a rel="nofollow" href="{{ external_source(dataset) }}">{{ _('Remote source') }}</a>
                                 </dd>
                                 {% endif%}
                             </dl>

--- a/udata_front/theme/gouvfr/templates/dataset/display.html
+++ b/udata_front/theme/gouvfr/templates/dataset/display.html
@@ -21,7 +21,6 @@
 {% set community_subtitle = _('Explore with %(certifier)s', certifier=config.SITE_TITLE ) %}
 {% set read_only_mode = config.READ_ONLY_MODE %}
 {# Harvesting source #}
-{% set external_source = dataset.extras['remote_url'] %}
 
 {% block extra_head %}
 {% cache cache_duration, 'dataset-extra-head', dataset.id|string, g.lang_code, dataset.last_modified|string %}
@@ -60,7 +59,7 @@
     {% endif %}
     {% if dataset.archived %}
     {% set title = _('This dataset has been archived automatically because it has been deleted from the remote platform.')
-        if dataset.extras.get('harvest:archived') == 'not-on-remote' else
+        if dataset.harvest and dataset.harvest.archived == 'not-on-remote' else
         _('This dataset has been archived.') %}
     <span class="fr-tag" title="{{ title }}">
         {{ _('Archived') }}
@@ -85,12 +84,10 @@
             </h1>
             <div class="fr-my-1w">
                 {{quality_score_with_tooltip(dataset, 'inline')}}
-                {% if not external_source %}
-                {{ _('Updated on %(date)s', date=dataset.last_modified|dateformat(format='long')) }}
+                {{ _('Updated on %(date)s', date=dataset.last_update|dateformat(format='long')) }}
                     {% if dataset.license %}
                     &mdash;
                     {%  endif %}
-                {% endif %}
                 {% if dataset.license %}
                 {% if dataset.license.url %}<a href="{{ dataset.license.url }}">{% endif %}
                 {{ dataset.license.title }}
@@ -121,11 +118,11 @@
             {% endif %}
         </div>
     </div>
-    {% if external_source %}
+    {% if external_source(dataset) %}
         {{ banner_info(
             "fr-icon-external-link-line",
             _("This dataset come from an external portal.&nbsp;<a href='{external_source}'>View the original source.</a>")
-            .format(external_source=external_source)
+            .format(external_source=external_source(dataset))
         )}}
     {% endif %}
     {{ hook('dataset.display.transport-banner') }}

--- a/udata_front/theme/gouvfr/templates/dataset/search-result.html
+++ b/udata_front/theme/gouvfr/templates/dataset/search-result.html
@@ -57,12 +57,10 @@
             </p>
             <div class="fr-mb-0 text-mention-grey">
                 {{quality_score_with_tooltip(dataset, "fr-hidden inline-sm")}}
-                {% if not external_source(dataset) %}
                 <span class="fr-hidden inline-sm">
                     &mdash;
                 </span>
                 {{ _('Updated on %(date)s', date=dataset.last_modified|dateformat(format='long')) }}
-                {% endif %}
             </div>
         </div>
         <ul class="fr-hidden fr-unhidden-sm fr-col-auto fr-tags-group flex-direction-column fr-grid-row--bottom self-center">


### PR DESCRIPTION
Follows https://github.com/opendatateam/udata/pull/2762.

Display harvest metadata in an html toggle next to extras toggle.
![image](https://user-images.githubusercontent.com/28541902/199990785-f964d1f0-5730-4c45-aa20-84a7a8282f56.png)

Show dates on top of dataset page and dataset card even for harvested datasets.
Use `last_update`, now based on more recent date for resources (modified, published and harvest modified date): https://github.com/opendatateam/udata/pull/2762#discussion_r1014046875.

This is a minimal step to mitigate the impact of separating the harvest dates, before dealing with https://github.com/etalab/data.gouv.fr/issues/856