### PR TITLE
Fix all js scripts waiting for DOMContentLoaded (already passed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix vanilla js scripts [#196](https://github.com/etalab/udata-front/pull/196)
 
 ## 3.1.0 (2023-01-18)
 

--- a/theme/js/components/vanilla/accordion.js
+++ b/theme/js/components/vanilla/accordion.js
@@ -29,29 +29,25 @@ The accordion panel needs to have :
 
 import { easing, tween, styler } from "popmotion";
 
-export default (() => {
-  document.addEventListener("DOMContentLoaded", () => {
-    const togglers = document.querySelectorAll("[data-accordion-button]");
+const togglers = document.querySelectorAll("[data-accordion-button]");
+console.log(togglers)
+togglers.forEach((toggler) => {
+  toggler.addEventListener("click", (ev) => {
+    ev.preventDefault();
+    const button = ev.target;
+    if (button instanceof HTMLElement) {
+      // Toggling the aria-expanded attribute on the button
+      button.toggleAttribute("aria-expanded");
 
-    togglers.forEach((toggler) => {
-      toggler.addEventListener("click", (ev) => {
-        ev.preventDefault();
-        const button = ev.target;
-        if (button instanceof HTMLElement) {
-          // Toggling the aria-expanded attribute on the button
-          button.toggleAttribute("aria-expanded");
-
-          /** @type {HTMLElement | null} */
-          const target = document.querySelector("#" + button.getAttribute("aria-controls"));
-          if (target) {
-            target.classList.toggle("active");
-            toggleAccordion(target, button.getAttribute("aria-expanded") === "true");
-          }
-        }
-      });
-    });
+      /** @type {HTMLElement | null} */
+      const target = document.querySelector("#" + button.getAttribute("aria-controls"));
+      if (target) {
+        target.classList.toggle("active");
+        toggleAccordion(target, button.getAttribute("aria-expanded") === "true");
+      }
+    }
   });
-})();
+});
 
 /**
  * @param {HTMLElement} target

--- a/theme/js/components/vanilla/accordion.js
+++ b/theme/js/components/vanilla/accordion.js
@@ -30,7 +30,6 @@ The accordion panel needs to have :
 import { easing, tween, styler } from "popmotion";
 
 const togglers = document.querySelectorAll("[data-accordion-button]");
-console.log(togglers)
 togglers.forEach((toggler) => {
   toggler.addEventListener("click", (ev) => {
     ev.preventDefault();

--- a/theme/js/components/vanilla/clipboard.js
+++ b/theme/js/components/vanilla/clipboard.js
@@ -18,8 +18,4 @@ Just have an element with an `id` ending with `-copy` and use clipboardJS API fo
 
 import ClipboardJS from "clipboard";
 
-export default (() => {
-  document.addEventListener("DOMContentLoaded", () => {
-    new ClipboardJS('[id$="-copy"]');
-  });
-})();
+new ClipboardJS('[id$="-copy"]');

--- a/theme/js/components/vanilla/sort-search.js
+++ b/theme/js/components/vanilla/sort-search.js
@@ -1,28 +1,24 @@
-export default (() => {
-    document.addEventListener("DOMContentLoaded", () => {
-        /**
-         * @type {NodeListOf<HTMLSelectElement>}
-         */
-        const selects = document.querySelectorAll("[data-select-sort]");
+/**
+ * @type {NodeListOf<HTMLSelectElement>}
+ */
+const selects = document.querySelectorAll("[data-select-sort]");
 
-        selects.forEach((select) => {
-            const options = select.querySelectorAll("option");
+selects.forEach((select) => {
+  const options = select.querySelectorAll("option");
 
-            options.forEach((option) => {
-                option.disabled = false;
-            });
-            if(select.form) {
-                select.addEventListener('change', e => {
-                    select.form?.dispatchEvent(new Event('submit'));
-                });
-                select.form.addEventListener('submit', e => {
-                    e.preventDefault();
-                    if(!select.value) {
-                        select.disabled = true;
-                    }
-                    select.form?.submit();
-                });
-            }
-        });
+  options.forEach((option) => {
+    option.disabled = false;
+  });
+  if(select.form) {
+    select.addEventListener('change', e => {
+      select.form?.dispatchEvent(new Event('submit'));
     });
-})();
+    select.form.addEventListener('submit', e => {
+      e.preventDefault();
+      if(!select.value) {
+          select.disabled = true;
+      }
+      select.form?.submit();
+    });
+  }
+});

--- a/theme/js/components/vanilla/tabs.js
+++ b/theme/js/components/vanilla/tabs.js
@@ -24,31 +24,27 @@ Tip : if the `aria-controls` is invalid (no div with specified `id`), the tabs w
 ```
 */
 
-export default (() => {
-  document.addEventListener("DOMContentLoaded", () => {
-    const tabs = document.querySelectorAll("[data-tabs]");
-    tabs.forEach((tab) => {
-      const tabsButtons = tab.querySelectorAll("[role=tab]");
-      tabsButtons.forEach((tabButton) => {
-        tabButton.addEventListener("click", (el) => {
-          el.preventDefault();
+const tabs = document.querySelectorAll("[data-tabs]");
+tabs.forEach((tab) => {
+  const tabsButtons = tab.querySelectorAll("[role=tab]");
+  tabsButtons.forEach((tabButton) => {
+    tabButton.addEventListener("click", (el) => {
+      el.preventDefault();
 
-          const previouslyActive = Array.from(tabsButtons).find((tab) =>
-            tab.getAttribute("aria-selected") === "true"
-          );
-          if (previouslyActive) {
-            previouslyActive.setAttribute("aria-selected", "false");
-            document
-              .getElementById(previouslyActive.getAttribute("aria-controls"))
-              .classList.remove("fr-unhidden");
-          }
+      const previouslyActive = Array.from(tabsButtons).find((tab) =>
+        tab.getAttribute("aria-selected") === "true"
+      );
+      if (previouslyActive) {
+        previouslyActive.setAttribute("aria-selected", "false");
+        document
+          .getElementById(previouslyActive.getAttribute("aria-controls"))
+          .classList.remove("fr-unhidden");
+      }
 
-          el.target.setAttribute("aria-selected", "true");
-          document
-            .getElementById(el.target.getAttribute("aria-controls"))
-            .classList.add("fr-unhidden");
-        });
-      });
+      el.target.setAttribute("aria-selected", "true");
+      document
+        .getElementById(el.target.getAttribute("aria-controls"))
+        .classList.add("fr-unhidden");
     });
   });
-})();
+});

--- a/theme/js/index.js
+++ b/theme/js/index.js
@@ -14,10 +14,10 @@ import Resources from "./components/dataset/resource/resources.vue";
 import SearchBar from "./components/utils/search-bar.vue";
 import Captcha from "./components/utils/captcha.vue";
 
-import Tabs from "./components/vanilla/tabs";
-import Accordion from "./components/vanilla/accordion";
-import Clipboard from "./components/vanilla/clipboard";
-import SortSearch from "./components/vanilla/sort-search";
+import "./components/vanilla/tabs";
+import "./components/vanilla/accordion";
+import "./components/vanilla/clipboard";
+import "./components/vanilla/sort-search";
 
 import Toaster from "@meforma/vue-toaster";
 

--- a/udata_front/theme/gouvfr/templates/home.html
+++ b/udata_front/theme/gouvfr/templates/home.html
@@ -118,7 +118,6 @@
                             class="fr-tag"
                             {% if loop.first %}
                                 aria-selected="true"
-                            {% else %}
                             {% endif %}
                         >
                             {{ label }}
@@ -140,7 +139,8 @@
         <div class="fr-hidden {% if loop.first %}fr-unhidden{% endif %}" role="tabpanel" id={{tab_id}}>
             <div class="fr-grid-row fr-grid-row--gutters fr-pt-1w">
                 {% for dataset in datasets %}
-                <div class="fr-col-12 fr-col-lg-4">{% include theme('dataset/card.html') %}
+                <div class="fr-col-12 fr-col-lg-4">
+                    {% include theme('dataset/card.html') %}
                 </div>
                 {% endfor %}
             </div>


### PR DESCRIPTION
Following https://github.com/etalab/udata-front/pull/183, the js is loaded after the `DOMContentLoaded` event. The scripts wait for this `DOMContentLoaded` event, that appended before them so they are never triggered.

Fix https://github.com/etalab/data.gouv.fr/issues/1031
Fix https://github.com/etalab/udata-front/issues/197
Also fix copy buttons on current dataset page, sort on reuses and organizations pages.