### PR TITLE
Make newsletter url configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Make newsletter url configurable [#205](https://github.com/etalab/udata-front/pull/205)
 
 ## 3.1.2 (2023-02-06)
 

--- a/udata_front/settings.py
+++ b/udata_front/settings.py
@@ -44,3 +44,6 @@ CAPTCHETAT_OAUTH_BASE_URL = None
 CAPTCHETAT_CLIENT_ID = None
 CAPTCHETAT_CLIENT_SECRET = None
 CAPTCHETAT_TOKEN_CACHE_KEY = 'captchetat-bearer-token'
+
+# Newsletter
+NEWSLETTER_SUBSCRIPTION_URL = 'https://infolettres.etalab.gouv.fr/subscribe/rn7y93le1'

--- a/udata_front/settings.py
+++ b/udata_front/settings.py
@@ -46,4 +46,4 @@ CAPTCHETAT_CLIENT_SECRET = None
 CAPTCHETAT_TOKEN_CACHE_KEY = 'captchetat-bearer-token'
 
 # Newsletter
-NEWSLETTER_SUBSCRIPTION_URL = 'https://infolettres.etalab.gouv.fr/subscribe/rn7y93le1'
+NEWSLETTER_SUBSCRIPTION_URL = 'https://f.info.data.gouv.fr/f/lp/infolettre-data-gouv-fr-landing-page/lk3q01y6'

--- a/udata_front/settings.py
+++ b/udata_front/settings.py
@@ -46,4 +46,4 @@ CAPTCHETAT_CLIENT_SECRET = None
 CAPTCHETAT_TOKEN_CACHE_KEY = 'captchetat-bearer-token'
 
 # Newsletter
-NEWSLETTER_SUBSCRIPTION_URL = 'https://f.info.data.gouv.fr/f/lp/infolettre-data-gouv-fr-landing-page/lk3q01y6'
+NEWSLETTER_SUBSCRIPTION_URL = 'https://f.info.data.gouv.fr/f/lp/infolettre-data-gouv-fr-landing-page/lk3q01y6'  # noqa

--- a/udata_front/theme/gouvfr/templates/footer.html
+++ b/udata_front/theme/gouvfr/templates/footer.html
@@ -56,7 +56,7 @@
                             </li>
                             <li class="fr-ml-9v">
                                 <a
-                                    href="https://infolettres.etalab.gouv.fr/subscribe/rn7y93le1"
+                                    href="{{ config.NEWSLETTER_SUBSCRIPTION_URL }}"
                                     title="{{ _('Newsletter') }}"
                                     class="fr-footer__top-link"
                                 >

--- a/udata_front/theme/gouvfr/templates/post/list.html
+++ b/udata_front/theme/gouvfr/templates/post/list.html
@@ -27,7 +27,7 @@
 <div class="alert-info bg-blue-400 text-white fr-my-9v">
     <div class="fr-container fr-py-2w">
         <p class="fr-m-0">{{ _('To stay up-to-date, you can subscribe to')}}
-            <a href="https://infolettres.etalab.gouv.fr/subscribe/rn7y93le1"
+            <a href=" {{ config.NEWSLETTER_SUBSCRIPTION_URL }}"
                 class="fr-text--bold text-white">
                 {{ _('our newsletter.')}}
             </a>


### PR DESCRIPTION
Following https://github.com/etalab/data.gouv.fr/issues/1017

I think we can change to the future url in our instance configuration :)
We could also set it as an empty string in  `settings.py` instead.