### PR TITLE
Show dsfr notice banner without JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Show a warning notice when JavaScript is disabled or failed to execute [#206](https://github.com/etalab/udata-front/pull/206)
 
 ## 3.1.2 (2023-02-06)
 

--- a/theme/less/components/well.less
+++ b/theme/less/components/well.less
@@ -27,6 +27,88 @@ They exist in many colors and two versions, primary with a solid background and 
     margin: var(--text-spacing);
 }
 
+html[data-fr-js] [data-show-no-js], html[data-fr-js=true] [data-show-no-js] {
+    display: none;
+}
+
+[data-show-no-js] {
+    opacity: 0;
+    height: 0;
+    animation: fadeIn 0.5s;
+    animation-delay: 2s;
+    animation-fill-mode: forwards;
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        height: 0;
+    }
+    to {
+        opacity: 1;
+        height: 100%;
+    }
+}
+
+/*
+    TODO : remove when dsfr >= 1.6
+*/
+.fr-notice {
+    position: relative;
+
+    --title-spacing: 0;
+    --text-spacing: 0;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+    background-color: var(--background-contrast-grey);
+    color: var(--text-title-grey);
+}
+
+.fr-notice__body {
+    position: relative;
+    padding: 0 2.5rem 0 2.5rem;
+}
+
+.fr-notice__body::before {
+    --icon-size: 1.5rem;
+    flex: 0 0 auto;
+    display: inline-block;
+    vertical-align: calc((0.75em - var(--icon-size)) * 0.5);
+    background-color: currentColor;
+    width: var(--icon-size);
+    height: var(--icon-size);
+    -webkit-mask-size: 100% 100%;
+    mask-size: 100% 100%;
+    position: absolute;
+    left: 0;
+}
+
+.fr-notice__title {
+    position: relative;
+    font-size: 1rem;
+    line-height: 1.5rem;
+    font-weight: 700;
+}
+
+.fr-notice--warning .fr-notice__body {
+    &:extend(.fr-icon-warning-line);
+    &:extend([class^="fr-icon-"]);
+}
+
+.fr-notice--warning .fr-notice__body::before {
+    &:extend(.fr-icon-warning-line::before);
+    &:extend([class^="fr-icon-"]::before);
+}
+
+.fr-notice--warning {
+    background-color: var(--background-contrast-warning);
+
+    --idle: transparent;
+    --hover: var(--background-contrast-warning-hover);
+    --active: var(--background-contrast-warning-active);
+    color: var(--text-default-warning);
+}
+
 .well {
     display: block;
     padding: @spacing-sm;

--- a/udata_front/theme/gouvfr/templates/header.html
+++ b/udata_front/theme/gouvfr/templates/header.html
@@ -206,7 +206,7 @@
             <div class="fr-notice__body">
                 <p class="fr-notice__title">
                     {{
-                        _("This is a degraded experience of {site}. Please enable JavaScript and use a modern browser.")
+                        _("This is a degraded experience of {site}. Please enable JavaScript and use an up to date browser.")
                             .format(site=current_site.title)
                     }}
                 </p>

--- a/udata_front/theme/gouvfr/templates/header.html
+++ b/udata_front/theme/gouvfr/templates/header.html
@@ -199,3 +199,18 @@
         </div>
     </div>
 </header>
+
+<div data-show-no-js>
+    <div class="fr-notice fr-notice--warning">
+        <div class="fr-container">
+            <div class="fr-notice__body">
+                <p class="fr-notice__title">
+                    {{
+                        _("This is a degraded experience of {site}. Please enable JavaScript and use a modern browser.")
+                            .format(site=current_site.title)
+                    }}
+                </p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/udata_front/theme/gouvfr/translations/gouvfr.pot
+++ b/udata_front/theme/gouvfr/translations/gouvfr.pot
@@ -6,10 +6,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: udata-front 3.0.2.dev0\n"
+"Project-Id-Version: udata-front 3.1.3.dev0\n"
 "Report-Msgid-Bugs-To: data.gouv@data.gouv.fr\n"
-"POT-Creation-Date: 2023-01-16 16:25+0100\n"
-"PO-Revision-Date: 2023-01-16 16:25+0100\n"
+"POT-Creation-Date: 2023-02-20 11:14+0100\n"
+"PO-Revision-Date: 2023-02-20 11:14+0100\n"
 "Last-Translator: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
 "Language: en\n"
 "Language-Team: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
@@ -368,6 +368,12 @@ msgstr ""
 msgid "Main Menu"
 msgstr ""
 
+#: udata_front/theme/gouvfr/templates/header.html:209
+msgid ""
+"This is a degraded experience of {site}. Please enable JavaScript and use an "
+"up to date browser."
+msgstr ""
+
 #: udata_front/theme/gouvfr/templates/api/oauth_error.html:12
 #: udata_front/theme/gouvfr/templates/errors/base.html:15
 #: udata_front/theme/gouvfr/templates/home.html:4
@@ -458,7 +464,7 @@ msgstr ""
 msgid "Reference datasets"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/home.html:134
+#: udata_front/theme/gouvfr/templates/home.html:133
 #: udata_front/theme/gouvfr/templates/topic/display.html:65
 msgid "See more datasets"
 msgstr ""


### PR DESCRIPTION
Close https://github.com/etalab/data.gouv.fr/issues/1013

This is based on the new notice component from DSFR 1.6.
It's backported here to prevent a DSFR update in this PR.

It uses the data-fr-js attribute that is added on DSFR JavaScript boot.