### PR TITLE
Fix RGAA criterion 9.3

### DIFF
--- a/theme/js/components/dataset/card-lg.vue
+++ b/theme/js/components/dataset/card-lg.vue
@@ -102,6 +102,7 @@
                     href="https://guides.etalab.gouv.fr/qualite/documenter-les-donnees/#le-score-de-qualite-des-metadonnees"
                     target="_blank"
                     rel="noopener"
+                    :title="$t('Learn more about this indicator - opens a new window')"
                   >
                     {{$t("Learn more about this indicator")}}
                   </a>

--- a/theme/js/components/dataset/resource/resource.vue
+++ b/theme/js/components/dataset/resource/resource.vue
@@ -43,11 +43,11 @@
         </div>
       </div>
       <div class="fr-col-auto fr-ml-auto">
-        <ul class="fr-grid-row fr-grid-row--middle no-wrap wrap-md">
-          <li class="text-default-error" v-if="unavailable">
+        <div class="fr-grid-row fr-grid-row--middle no-wrap wrap-md">
+          <p class="text-default-error fr-m-0" v-if="unavailable">
             {{$t('Unavailable')}}
-          </li>
-          <li class="fr-col-auto fr-ml-3v">
+          </p>
+          <p class="fr-col-auto fr-ml-3v fr-m-0">
             <button
               @click="expand"
               role="button"
@@ -63,18 +63,18 @@
                 {{hasExplore ? $t('See data') : $t('See metadata')}}
               </template>
             </button>
-          </li>
-          <li class="fr-col-auto fr-ml-3v" v-if="resource.format === 'url'">
+          </p>
+          <p class="fr-col-auto fr-ml-3v fr-m-0" v-if="resource.format === 'url'">
             <a
               :href="resource.latest"
-              :title="$t('Resource link')"
+              :title="$t('Resource link - opens a new window')"
               rel="nofollow noopener"
               target="_blank"
               class="fr-btn fr-btn--secondary fr-btn--secondary-grey-500 fr-icon-external-link-line fr-icon--sm"
             >
             </a>
-          </li>
-          <li class="fr-col-auto fr-ml-3v" v-else>
+          </p>
+          <p class="fr-col-auto fr-ml-3v fr-m-0" v-else>
             <a
               :href="resource.latest"
               :title="$t('Download resource')"
@@ -82,15 +82,15 @@
               class="fr-btn fr-btn--secondary fr-btn--secondary-grey-500 fr-icon-download-line fr-icon--sm"
             >
             </a>
-          </li>
-          <li class="fr-col-auto fr-ml-3v" v-if="canEdit">
+          </p>
+          <p class="fr-col-auto fr-ml-3v fr-m-0" v-if="canEdit">
             <EditButton
               :dataset-id="datasetId"
               :resource-id="resource.id"
               :is-community-resource="isCommunityResource"
             />
-          </li>
-        </ul>
+          </p>
+        </div>
       </div>
     </header>
     <section

--- a/theme/js/locales/en.json
+++ b/theme/js/locales/en.json
@@ -51,7 +51,6 @@
   "X downloads": "{count} downloads",
   "Nameless resource": "Nameless resource",
   "Preview": "Preview",
-  "Resource link": "Resource link",
   "Download resource": "Download resource",
   "URL": "URL",
   "Permalink": "Permalink",
@@ -151,5 +150,7 @@
   "File description": "File description",
   "Schemas allow to describe data models, discover how schemas improve your data quality and the available use cases on {address}": "Schemas allow to describe data models, discover how schemas improve your data quality and the available use cases on {address}",
   "schema:": "schema:",
-  "Invalid": "Invalid"
+  "Invalid": "Invalid",
+  "Learn more about this indicator - opens a new window": "Learn more about this indicator - opens a new window",
+  "Resource link - opens a new window": "Resource link - opens a new window"
 }

--- a/theme/js/locales/es.json
+++ b/theme/js/locales/es.json
@@ -51,7 +51,6 @@
   "X downloads": "{count} downloads",
   "Nameless resource": "Nameless resource",
   "Preview": "Preview",
-  "Resource link": "Resource link",
   "Download resource": "Download resource",
   "URL": "URL",
   "Permalink": "Permalink",
@@ -151,5 +150,7 @@
   "File description": "File description",
   "Schemas allow to describe data models, discover how schemas improve your data quality and the available use cases on {address}": "Schemas allow to describe data models, discover how schemas improve your data quality and the available use cases on {address}",
   "schema:": "schema:",
-  "Invalid": "Invalid"
+  "Invalid": "Invalid",
+  "Learn more about this indicator - opens a new window": "",
+  "Resource link - opens a new window": ""
 }

--- a/theme/js/locales/fr.json
+++ b/theme/js/locales/fr.json
@@ -51,7 +51,6 @@
   "X downloads": "{count} téléchargements",
   "Nameless resource": "Ressource sans nom",
   "Preview": "Prévisualiser",
-  "Resource link": "Lien de la ressource",
   "Download resource": "Télécharger la ressource",
   "URL": "URL",
   "Permalink": "URL stable",
@@ -151,5 +150,7 @@
   "File description": "Description du fichier",
   "Schemas allow to describe data models, discover how schemas improve your data quality and the available use cases on {address}": "Les schémas de données permettent de décrire des modèles de données, découvrez comment les schémas améliorent la qualité des données et quels sont les cas d'usages possibles sur {address}",
   "schema:": "schéma :",
-  "Invalid": "Invalide"
+  "Invalid": "Invalide",
+  "Learn more about this indicator - opens a new window": "",
+  "Resource link - opens a new window": ""
 }

--- a/theme/js/locales/it.json
+++ b/theme/js/locales/it.json
@@ -51,7 +51,6 @@
   "X downloads": "{count} downloads",
   "Nameless resource": "Nameless resource",
   "Preview": "Preview",
-  "Resource link": "Resource link",
   "Download resource": "Download resource",
   "URL": "URL",
   "Permalink": "Permalink",
@@ -151,5 +150,7 @@
   "File description": "File description",
   "Schemas allow to describe data models, discover how schemas improve your data quality and the available use cases on {address}": "Schemas allow to describe data models, discover how schemas improve your data quality and the available use cases on {address}",
   "schema:": "schema:",
-  "Invalid": "Invalid"
+  "Invalid": "Invalid",
+  "Learn more about this indicator - opens a new window": "",
+  "Resource link - opens a new window": ""
 }

--- a/theme/js/locales/pt.json
+++ b/theme/js/locales/pt.json
@@ -51,7 +51,6 @@
   "X downloads": "{count} transferências",
   "Nameless resource": "Recurso sem nome",
   "Preview": "Visualização",
-  "Resource link": "Link do recurso",
   "Download resource": "Baixar recurso",
   "URL": "URL",
   "Permalink": "URL stable",
@@ -151,5 +150,7 @@
   "File description": "File description",
   "Schemas allow to describe data models, discover how schemas improve your data quality and the available use cases on {address}": "Schemas allow to describe data models, discover how schemas improve your data quality and the available use cases on {address}",
   "schema:": "schema:",
-  "Invalid": "Invalid"
+  "Invalid": "Invalid",
+  "Learn more about this indicator - opens a new window": "",
+  "Resource link - opens a new window": ""
 }

--- a/theme/js/locales/sr.json
+++ b/theme/js/locales/sr.json
@@ -51,7 +51,6 @@
   "X downloads": "{count} downloads",
   "Nameless resource": "Resurs bez imena",
   "Preview": "Pregled",
-  "Resource link": "Veza resursa",
   "Download resource": "Preuzmite resurs",
   "URL": "URL",
   "Permalink": "Trajni link",
@@ -151,5 +150,7 @@
   "File description": "File description",
   "Schemas allow to describe data models, discover how schemas improve your data quality and the available use cases on {address}": "Schemas allow to describe data models, discover how schemas improve your data quality and the available use cases on {address}",
   "schema:": "schema:",
-  "Invalid": "Invalid"
+  "Invalid": "Invalid",
+  "Learn more about this indicator - opens a new window": "",
+  "Resource link - opens a new window": ""
 }

--- a/theme/less/components/breadcrumbs.less
+++ b/theme/less/components/breadcrumbs.less
@@ -4,66 +4,39 @@ name: Breadcrumbs
 category: 3 - Components
 ---
 
-Being lost on a website isn't fun for your users, thanks to `.breadcrumbs` you can avoid this issue entierly.
+Breadcrumbs allow a user to see where it is in a website.
 
 ```breadcrumbs.html
-<ul class="breadcrumbs">
-    <li><a href="#">Accueil</a></li>
-    <li><a href="#">Ministère des solidarités et de la santé</a></li>
-    <li class="active">Consulation citoyenne en ligne sur les retraites</li>
-</ul>
+<nav role="navigation" class="fr-breadcrumb" aria-label="vous êtes ici :">
+    <button class="fr-breadcrumb__button" aria-expanded="false" aria-controls="breadcrumb-1">Voir le fil d’Ariane</button>
+    <div class="fr-collapse" id="breadcrumb-1">
+        <ol class="fr-breadcrumb__list">
+            <li>
+                <a class="fr-breadcrumb__link" href="/">Accueil</a>
+            </li>
+            <li>
+                <a class="fr-breadcrumb__link" href="/segment-1/">Segment 1</a>
+            </li>
+            <li>
+                <a class="fr-breadcrumb__link" href="/segment-1/segment-2/">Segment 2</a>
+            </li>
+            <li>
+                <a class="fr-breadcrumb__link" href="/segment-1/segment-2/segment-3/">Segment 3</a>
+            </li>
+            <li>
+                <a class="fr-breadcrumb__link" href="/segment-1/segment-2/segment-3/segment-4/">Segment 4</a>
+            </li>
+            <li>
+                <a class="fr-breadcrumb__link" href="/segment-1/segment-2/segment-3/segment-4/segment-5/">Segment 5</a>
+            </li>
+            <li>
+                <a class="fr-breadcrumb__link" aria-current="page">Page Actuelle</a>
+            </li>
+        </ol>
+    </div>
+</nav>
 ```
 */
 
-.breadcrumbs {
-    padding-left: 0;
-    margin: 0;
-    font-size: @font-size-xs;
-
-    display: flex;
-
-    li {
-        position: relative;
-        display: inline-block;
-        max-width: 20em;
-        padding: 4px;
-        padding-left: 1em;
-        overflow: hidden;
-        white-space: nowrap;
-        text-overflow: ellipsis;
-
-        flex-shrink: 0;
-
-        color: @grey-380;
-
-        a {
-            color: inherit;
-        }
-
-        + li {
-            margin-left: 0.5em;
-        }
-
-        &:last-child {
-            font-weight: @font-weight-bold;
-            flex-shrink: 1;
-        }
-
-        &::before {
-            position: absolute;
-            top: 0.1em;
-            left: 0;
-            width: 0.5em;
-            height: 100%;
-            background-image: url(~"@{icon-chevron}");
-            background-repeat: no-repeat;
-            background-position: center;
-            background-size: 75%;
-            content: "";
-        }
-
-        &:first-child::before {
-            display: none;
-        }
-    }
-}
+// tabs from dsfr
+@import (less) "@gouvfr/dsfr/dist/component/breadcrumb/breadcrumb.css";

--- a/theme/less/content/links.less
+++ b/theme/less/content/links.less
@@ -55,8 +55,6 @@ You can use links from DSFR. It uses DSFR colors and conventions. It allows you 
 @import (less) "@gouvfr/dsfr/dist/component/link/link.css";
 
 a {
-    color: @blue-400;
-    cursor: pointer;
 
     &:focus {
         outline: 5px auto -webkit-focus-ring-color;

--- a/udata_front/theme/gouvfr/templates/api/card.html
+++ b/udata_front/theme/gouvfr/templates/api/card.html
@@ -6,7 +6,7 @@
             {{ api.title }}
         </h4>
         <p class="fr-col-auto fr-m-0">
-            {{_('See on <a target="_blank" rel="noopener" title="See {title} on api.gouv.fr" href="{url}">api.gouv.fr</a>')
+            {{_('See on <a target="_blank" rel="noopener" title="See {title} on api.gouv.fr - opens a new window" href="{url}">api.gouv.fr</a>')
                 .format(
                     title=api.title,
                     url="https://api.gouv.fr" + api.path

--- a/udata_front/theme/gouvfr/templates/dataset/display.html
+++ b/udata_front/theme/gouvfr/templates/dataset/display.html
@@ -32,10 +32,18 @@
 {% endblock %}
 
 {% block breadcrumb %}
-{% cache cache_duration, 'dataset-breadcrumb', dataset.id|string, g.lang_code, dataset.last_modified|string %}
-<li><a href="{{ url_for('datasets.list') }}">{{ _('Datasets') }}</a></li>
-<li class="active" aria-current="page">{{ dataset.acronym or dataset.title|truncate(128) }}</li>
-{% endcache %}
+    {% cache cache_duration, 'dataset-breadcrumb', dataset.id|string, g.lang_code, dataset.last_modified|string %}
+        <li>
+            <a class="fr-breadcrumb__link" href="{{ url_for('datasets.list') }}">
+                {{ _('Datasets') }}
+            </a>
+        </li>
+        <li>
+            <a class="fr-breadcrumb__link" aria-current="page">
+                {{ dataset.acronym or dataset.title|truncate(128) }}
+            </a>
+        </li>
+    {% endcache %}
 {% endblock %}
 
 {% block toolbar %}

--- a/udata_front/theme/gouvfr/templates/dataset/followers.html
+++ b/udata_front/theme/gouvfr/templates/dataset/followers.html
@@ -1,9 +1,21 @@
 {% extends theme('layouts/1-column.html') %}
 
 {% block breadcrumb %}
-    <li><a href="{{ url_for('datasets.list') }}">{{ _('Datasets') }}</a></li>
-    <li><a href="{{ url_for('datasets.show', dataset=dataset) }}">{{ dataset.name|truncate(120) }}</a></li>
-    <li class="active" aria-current="page">{{ _('Followers') }}</li>
+    <li>
+        <a class="fr-breadcrumb__link" href="{{ url_for('datasets.list') }}">
+            {{ _('Datasets') }}
+        </a>
+    </li>
+    <li>
+        <a class="fr-breadcrumb__link" href="{{ url_for('datasets.show', dataset=dataset) }}">
+            {{ dataset.name|truncate(120) }}
+        </a>
+    </li>
+    <li>
+        <a class="fr-breadcrumb__link" aria-current="page">
+            {{ _('Followers') }}
+        </a>
+    </li>
 {% endblock %}
 
 {% block main_content %}

--- a/udata_front/theme/gouvfr/templates/dataset/list.html
+++ b/udata_front/theme/gouvfr/templates/dataset/list.html
@@ -4,8 +4,10 @@
 {% from theme('macros/banner_info.html') import banner_info %}
 
 {% block breadcrumb %}
-<li class="active" aria-current="page">
-    {{ _('Datasets') }}
+<li>
+    <a class="fr-breadcrumb__link" aria-current="page">
+        {{ _('Datasets') }}
+    </a>
 </li>
 {% endblock %}
 
@@ -27,7 +29,7 @@
 
 {% block main_content %}
 <section
-    class="fr-container fr-container--search fr-py-2w vuejs"
+    class="fr-container fr-container--search vuejs"
 >
     <h1 class="fr-mb-1w">{{_('Datasets')}}</h1>
     <div class="fr-grid-row fr-grid-row--middle justify-between">

--- a/udata_front/theme/gouvfr/templates/dataset/resource/card.html
+++ b/udata_front/theme/gouvfr/templates/dataset/resource/card.html
@@ -50,7 +50,7 @@
                     <li class="fr-col-auto">
                         <a
                             href="{{ resource.latest }}"
-                            title="{{ _('Resource link') }}"
+                            title="{{ _('Resource link - opens a new window') }}"
                             rel="nofollow noopener"
                             target="_blank"
                             class="fr-btn fr-btn--sm fr-icon-external-link-line"

--- a/udata_front/theme/gouvfr/templates/home.html
+++ b/udata_front/theme/gouvfr/templates/home.html
@@ -18,21 +18,29 @@
                 <h1 class="fr-mt-0 fr-mb-2w">{{ _('Open platform for French public data') }}</h1>
                 <div>
                     <h2 class="fr-text--md fr-my-0">{{ _('Featured topics') }}</h2>
-                    <a href="{{ url_for('gouvfr.show_page', slug='donnees-energie') }}"
-                        class="btn-venti fr-my-2w bg-orange-100">
-                        Données relatives aux
-                        <strong>Énergies</strong>
-                    </a>
-                    <a href="{{ url_for('gouvfr.show_page', slug='donnees-geographiques') }}"
-                        class="btn-venti fr-my-2w bg-blue-450">
-                        Données à composante
-                        <strong>Géographique</strong>
-                    </a>
-                    <a href="{{ url_for('gouvfr.show_page', slug='donnees-logement-urbanisme') }}"
-                        class="btn-venti bg-green-400">
-                        Données relatives au
-                        <strong>Logement et à l'Urbanisme</strong>
-                    </a>
+                    <ul>
+                        <li>
+                            <a href="{{ url_for('gouvfr.show_page', slug='donnees-energie') }}"
+                                class="btn-venti fr-my-2w bg-orange-100">
+                                Données relatives aux
+                                <strong>Énergies</strong>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="{{ url_for('gouvfr.show_page', slug='donnees-geographiques') }}"
+                                class="btn-venti fr-my-2w bg-blue-450">
+                                Données à composante
+                                <strong>Géographique</strong>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="{{ url_for('gouvfr.show_page', slug='donnees-logement-urbanisme') }}"
+                                class="btn-venti bg-green-400">
+                                Données relatives au
+                                <strong>Logement et à l'Urbanisme</strong>
+                            </a>
+                        </li>
+                    </ul>
                     <div class="fr-grid-row justify-center fr-mt-2w">
                         <a
                             href="{{ url_for('gouvfr.show_page', slug='thematiques-a-la-une') }}"

--- a/udata_front/theme/gouvfr/templates/macros/banner_info.html
+++ b/udata_front/theme/gouvfr/templates/macros/banner_info.html
@@ -22,6 +22,7 @@
                     href="{{ link }}"
                     rel="noopener"
                     target="_blank"
+                    title="{{ button }} _('- opens a new window')"
                 >
                     {{ button }}
                 </a>

--- a/udata_front/theme/gouvfr/templates/macros/breadcrumb.html
+++ b/udata_front/theme/gouvfr/templates/macros/breadcrumb.html
@@ -1,27 +1,30 @@
 {% macro breadcrumb(tpl) %}
 {% if tpl.breadcrumb and tpl.breadcrumb() or tpl.breadcrumb_bar and tpl.breadcrumb_bar() %}
-<section class="breadcrumb-bar fr-py-3w">
+<section class="breadcrumb-bar fr-pt-1w">
     <div class="fr-container">
         <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
-            <nav rol="navigation" aria-label="{{_("You're here:")}}" class="fr-col-12 fr-col-md-6">
-                {% if tpl.breadcrumb and tpl.breadcrumb() %}
-                <ol class="breadcrumbs">
-                    <li>
-                        <a href="{{ url_for('site.home') }}">
-                            {{ _('Home') }}
-                        </a>
-                    </li>
-                    {{ tpl.breadcrumb() }}
-                </ol>
-                {% endif %}
+        {% if tpl.breadcrumb and tpl.breadcrumb() %}
+            <nav rol="navigation" aria-label="{{_("You're here:")}}" class="fr-breadcrumb fr-col-12 fr-col-md-6">
+                <button class="fr-breadcrumb__button" aria-expanded="false" aria-controls="breadcrumb-1">{{_("See breadcrumbs")}}</button>
+                <div class="fr-collapse" id="breadcrumb-1">
+                    <ol class="fr-breadcrumb__list">
+                        <li>
+                            <a class="fr-breadcrumb__link" href="{{ url_for('site.home') }}">
+                                {{ _('Home') }}
+                            </a>
+                        </li>
+                        {{ tpl.breadcrumb() }}
+                    </ol>
+                </div>
             </nav>
+            {% endif %}
+            {% if tpl.toolbar and tpl.toolbar() %}
             <div class="fr-col-12 fr-col-md-6">
-                {% if tpl.toolbar and tpl.toolbar() %}
                 <div class="fr-grid-row fr-grid-row--right">
                     {{ tpl.toolbar() }}
                 </div>
-                {% endif %}
             </div>
+            {% endif %}
         </div>
     </div>
 </section>

--- a/udata_front/theme/gouvfr/templates/macros/quality_score_tooltip.html
+++ b/udata_front/theme/gouvfr/templates/macros/quality_score_tooltip.html
@@ -55,6 +55,7 @@
                 href="https://guides.etalab.gouv.fr/qualite/documenter-les-donnees/#le-score-de-qualite-des-metadonnees"
                 target="_blank"
                 rel="noopener"
+                title="{{_('Learn more about this indicator - opens a new window')}}"
             >
                 {{_("Learn more about this indicator")}}
             </a>

--- a/udata_front/theme/gouvfr/templates/metrics.html
+++ b/udata_front/theme/gouvfr/templates/metrics.html
@@ -7,7 +7,9 @@
 } %}
 
 {% block breadcrumb %}
-    <li class="active" aria-current="page">{{ _('Metrics') }}</li>
+    <li>
+        <a class="fr-breadcrumb__link" aria-current="page">{{ _('Metrics') }}</a>
+    </li>
 {% endblock %}
 
 {% block main_content %}

--- a/udata_front/theme/gouvfr/templates/organization/display.html
+++ b/udata_front/theme/gouvfr/templates/organization/display.html
@@ -18,8 +18,16 @@
 
 {% block breadcrumb %}
 {% cache cache_duration, 'org-breadcrumb', org.id|string, g.lang_code, org.last_modified|string %}
-<li><a href="{{ url_for('organizations.list') }}">{{ _('Organizations') }}</a></li>
-<li class="active" aria-current="page">{{ org.name }}</li>
+<li>
+    <a class="fr-breadcrumb__link" href="{{ url_for('organizations.list') }}">
+        {{ _('Organizations') }}
+    </a>
+</li>
+<li>
+    <a class="fr-breadcrumb__link" aria-current="page">
+        {{ org.name }}
+    </a>
+</li>
 {% endcache %}
 {% endblock %}
 

--- a/udata_front/theme/gouvfr/templates/organization/list.html
+++ b/udata_front/theme/gouvfr/templates/organization/list.html
@@ -12,12 +12,10 @@
 {% set bundle = 'search' %}
 
 {% block breadcrumb %}
-<li class="active" aria-current="page">
-    {{ _('Organizations') }}
-    <small>{{ _('%(start)s to %(end)s on %(total)s',
-            start=organizations.page_start,
-            end=organizations.page_end,
-            total=organizations.total) }}</small>
+<li>
+    <a class="fr-breadcrumb__link" aria-current="page">
+        {{ _('Organizations') }}
+    </a>
 </li>
 {% endblock %}
 
@@ -29,7 +27,7 @@
 ] %}
 
 {% block main_content %}
-<section class="fr-container fr-py-2w">
+<section class="fr-container">
     <h1 class="fr-mb-1w">{{_('Organizations')}}</h1>
     <div>{{_('Search among %(count)s organizations on %(site)s', count=current_site.metrics['organizations']|format_number, site=current_site.title)}}</div>
     <div class="fr-pt-3v">

--- a/udata_front/theme/gouvfr/templates/post/display.html
+++ b/udata_front/theme/gouvfr/templates/post/display.html
@@ -112,34 +112,35 @@
     <nav
         role="navigation"
         aria-label="{{_("Navigate in the post collection")}}"
-        class="fr-grid-row fr-grid-row--gutters justify-between"
     >
-        <div class="fr-col-12 fr-col-md-3 text-align-center-md">
-            {% if previous_post %}
-            <a
-                href="{{ previous_post.display_url }}"
-                class="fr-btn fr-btn--secondary fr-icon-arrow-left-s-line fr-btn--icon-left"
-            >
-                {{ _('Previous post') }}
-            </a>
-            {% endif %}
-        </div>
-        <div class="fr-col-12 fr-col-md-6 fr-my-md-2w text-align-center">
-            <a href="{{ url_for('posts.list') }}" class="fr-btn fr-btn--secondary">
-                {{ _('All posts') }}
-            </a>
-        </div>
-        <div class="fr-col-12 fr-col-md-3 text-align-right text-align-center-md">
-            {% if next_post %}
-            <a
-                href="{{ next_post.display_url }}"
-                class="fr-btn fr-btn--secondary fr-icon-arrow-right-s-line fr-btn--icon-right"
-            >
-                {{ _('Next post') }}
-            </a>
-            {% endif %}
-        </div>
-    </div>
+        <ul class="fr-grid-row fr-grid-row--gutters justify-between">
+            <li class="fr-col-12 fr-col-md-3 text-align-center-md">
+                {% if previous_post %}
+                <a
+                    href="{{ previous_post.display_url }}"
+                    class="fr-btn fr-btn--secondary fr-icon-arrow-left-s-line fr-btn--icon-left"
+                >
+                    {{ _('Previous post') }}
+                </a>
+                {% endif %}
+            </li>
+            <li class="fr-col-12 fr-col-md-6 fr-my-md-2w text-align-center">
+                <a href="{{ url_for('posts.list') }}" class="fr-btn fr-btn--secondary">
+                    {{ _('All posts') }}
+                </a>
+            </li>
+            <li class="fr-col-12 fr-col-md-3 text-align-right text-align-center-md">
+                {% if next_post %}
+                <a
+                    href="{{ next_post.display_url }}"
+                    class="fr-btn fr-btn--secondary fr-icon-arrow-right-s-line fr-btn--icon-right"
+                >
+                    {{ _('Next post') }}
+                </a>
+                {% endif %}
+            </li>
+        </ul>
+    </nav>
 </section>
 {% endif %}
 

--- a/udata_front/theme/gouvfr/templates/post/display.html
+++ b/udata_front/theme/gouvfr/templates/post/display.html
@@ -14,8 +14,16 @@
 {% block title %}{{ post.name }}{% endblock %}
 
 {% block breadcrumb %}
-<li><a href="{{ url_for('posts.list') }}">{{ _('News') }}</a></li>
-<li class="active" aria-current="page">{{ post.name }}</li>
+<li>
+    <a class="fr-breadcrumb__link" href="{{ url_for('posts.list') }}">
+        {{ _('News') }}
+    </a>
+</li>
+<li>
+    <a class="fr-breadcrumb__link" aria-current="page">
+        {{ post.name }}
+    </a>
+</li>
 {% endblock %}
 
 

--- a/udata_front/theme/gouvfr/templates/post/list.html
+++ b/udata_front/theme/gouvfr/templates/post/list.html
@@ -23,7 +23,7 @@
     <h1 class="fr-mb-0">{{ _('Posts') }}</h1>
 </div>
 <div class="alert-info bg-blue-400 text-white fr-my-9v">
-    <div class="fr-container">
+    <div class="fr-container fr-py-2w">
         <p class="fr-m-0">{{ _('To stay up-to-date, you can subscribe to')}}
             <a href=" {{ config.NEWSLETTER_SUBSCRIPTION_URL }}"
                 class="fr-text--bold text-white">

--- a/udata_front/theme/gouvfr/templates/post/list.html
+++ b/udata_front/theme/gouvfr/templates/post/list.html
@@ -11,12 +11,10 @@
 {% set bundle = 'search' %}
 
 {% block breadcrumb %}
-<li class="active" aria-current="page">
-    {{ _('Posts') }}
-    <span>{{ _('%(start)s to %(end)s on %(total)s',
-            start=posts.page_start,
-            end=posts.page_end,
-            total=posts.total) }}</span>
+<li>
+    <a class="fr-breadcrumb__link" aria-current="page">
+        {{ _('Posts') }}
+    </a>
 </li>
 {% endblock %}
 
@@ -25,7 +23,7 @@
     <h1 class="fr-mb-0">{{ _('Posts') }}</h1>
 </div>
 <div class="alert-info bg-blue-400 text-white fr-my-9v">
-    <div class="fr-container fr-py-2w">
+    <div class="fr-container">
         <p class="fr-m-0">{{ _('To stay up-to-date, you can subscribe to')}}
             <a href=" {{ config.NEWSLETTER_SUBSCRIPTION_URL }}"
                 class="fr-text--bold text-white">

--- a/udata_front/theme/gouvfr/templates/reuse/display.html
+++ b/udata_front/theme/gouvfr/templates/reuse/display.html
@@ -31,8 +31,16 @@
 
 {% block breadcrumb %}
 {% cache cache_duration, 'reuse-breadcrumb', reuse.id|string, g.lang_code, reuse.last_modified|string %}
-<li><a href="{{ url_for('reuses.list') }}">{{ _('Reuses') }}</a></li>
-<li class="active" aria-current="page">{{ reuse.title }}</li>
+<li>
+    <a class="fr-breadcrumb__link" href="{{ url_for('reuses.list') }}">
+        {{ _('Reuses') }}
+    </a>
+</li>
+<li>
+    <a class="fr-breadcrumb__link" aria-current="page">
+        {{ reuse.title }}
+    </a>
+</li>
 {% endcache %}
 {% endblock %}
 

--- a/udata_front/theme/gouvfr/templates/reuse/list.html
+++ b/udata_front/theme/gouvfr/templates/reuse/list.html
@@ -12,12 +12,10 @@
 {% set bundle = 'search' %}
 
 {% block breadcrumb %}
-<li class="active" aria-current="page">
-    {{ _('Reuses') }}
-    <small>{{ _('%(start)s to %(end)s on %(total)s',
-            start=reuses.page_start,
-            end=reuses.page_end,
-            total=reuses.total) }}</small>
+<li>
+    <a class="fr-breadcrumb__link" aria-current="page">
+        {{ _('Reuses') }}
+    </a>
 </li>
 {% endblock %}
 
@@ -47,7 +45,7 @@
 ] %}
 
 {% block main_content %}
-<section class="fr-container fr-py-2w">
+<section class="fr-container">
     <h1 class="fr-mb-1w">{{_('Reuses')}}</h1>
     <div class="fr-grid-row fr-grid-row--middle justify-between">
         <div>{{_('Search among %(count)s reuses on %(site)s', count=current_site.metrics['reuses']|format_number, site=current_site.title)}}</div>

--- a/udata_front/theme/gouvfr/templates/security/register_user.html
+++ b/udata_front/theme/gouvfr/templates/security/register_user.html
@@ -10,7 +10,12 @@
                 <form class="form" method="post" action="{{ url_for('security.register') }}" data-cy="register">
                     <h1 class="fr-h4 fr-mb-0 text-align-center">{{ _('Sign up') }}</h1>
                         <p class="fr-mt-2w fr-mb-1w f-light fr-text--sm">
-                            <a href="{{config.GUIDES_USER_ACCOUNT_URL}}" target="_blank" rel="noopener">
+                            <a
+                                href="{{config.GUIDES_USER_ACCOUNT_URL}}"
+                                target="_blank"
+                                rel="noopener"
+                                title="{{_('Why create an account? - opens a new window')}}"
+                            >
                                 {{ _('Why create an account?') }}
                             </a>
                         </p>

--- a/udata_front/theme/gouvfr/templates/site/dashboard.html
+++ b/udata_front/theme/gouvfr/templates/site/dashboard.html
@@ -11,7 +11,11 @@
 {% set body_class = 'dashboard' %}
 
 {% block breadcrumb %}
-    <li class="active" aria-current="page">{{ _('Dashboard') }}</li>
+<li>
+    <a class="fr-breadcrumb__link" aria-current="page">
+        {{ _('Dashboard') }}
+    </a>
+</li>
 {% endblock %}
 
 {% block content %}

--- a/udata_front/theme/gouvfr/templates/suivi.html
+++ b/udata_front/theme/gouvfr/templates/suivi.html
@@ -6,7 +6,11 @@
 } %}
 
 {% block breadcrumb %}
-<li class="active" aria-current="page">Suivi d'audience et vie privée</li>
+<li>
+    <a class="fr-breadcrumb__link" aria-current="page">
+        Suivi d'audience et vie privée
+    </a>
+</li>
 {% endblock %}
 
 {% block content %}

--- a/udata_front/theme/gouvfr/templates/topic/datasets.html
+++ b/udata_front/theme/gouvfr/templates/topic/datasets.html
@@ -11,16 +11,20 @@
 
 {% block breadcrumb %}
     <li>
-        <a href="{{ url_for('topics.display', topic=topic) }}">
+        <a class="fr-breadcrumb__link" href="{{ url_for('topics.display', topic=topic) }}">
         {{ topic.name }}
         </a>
     </li>
-    <li class="active" aria-current="page">
-        {{ _('Datasets') }}
-        <small>{{ _('%(start)s to %(end)s on %(total)s',
-            start=datasets.page_start,
-            end=datasets.page_end,
-            total=datasets.total) }}</small>
+    <li>
+        <a class="fr-breadcrumb__link" aria-current="page">
+            {{ _('Datasets') }}
+            <small>
+                {{ _('%(start)s to %(end)s on %(total)s',
+                    start=datasets.page_start,
+                    end=datasets.page_end,
+                    total=datasets.total) }}
+            </small>
+        </a>
     </li>
 {% endblock %}
 

--- a/udata_front/theme/gouvfr/templates/topic/reuses.html
+++ b/udata_front/theme/gouvfr/templates/topic/reuses.html
@@ -11,16 +11,20 @@
 
 {% block breadcrumb %}
     <li>
-        <a href="{{ url_for('topics.display', topic=topic) }}">
+        <a class="fr-breadcrumb__link" href="{{ url_for('topics.display', topic=topic) }}">
         {{ topic.name }}
         </a>
     </li>
-    <li class="active" aria-current="page">
-        {{ _('Reuses') }}
-        <small>{{ _('%(start)s to %(end)s on %(total)s',
-            start=reuses.page_start,
-            end=reuses.page_end,
-            total=reuses.total) }}</small>
+    <li>
+        <a class="fr-breadcrumb__link" aria-current="page">
+            {{ _('Reuses') }}
+            <small>
+                {{ _('%(start)s to %(end)s on %(total)s',
+                    start=reuses.page_start,
+                    end=reuses.page_end,
+                    total=reuses.total) }}
+            </small>
+        </a>
     </li>
 {% endblock %}
 

--- a/udata_front/theme/gouvfr/templates/user/activity.html
+++ b/udata_front/theme/gouvfr/templates/user/activity.html
@@ -1,8 +1,12 @@
 {% extends theme('user/base.html') %}
 
 {% block breadcrumb %}
-    {{ super() }}
-    <li class="active" aria-current="page">{{ _('Activity') }}</li>
+{{ super() }}
+<li>
+    <a class="fr-breadcrumb__link" aria-current="page">
+        {{ _('Activity') }}
+    </a>
+</li>
 {% endblock %}
 
 {% set user_tab = 'activity' %}

--- a/udata_front/theme/gouvfr/templates/user/base.html
+++ b/udata_front/theme/gouvfr/templates/user/base.html
@@ -11,8 +11,16 @@
 } %}
 
 {% block breadcrumb %}
-    <li>{{ _('Users') }}</li>
-    <li><a href="{{ url_for('users.show', user=user) }}">{{ user.fullname }}</a></li>
+<li>
+    <a class="fr-breadcrumb__link">
+        {{ _('Users') }}
+    </a>
+</li>
+<li>
+    <a class="fr-breadcrumb__link" aria-current="page">
+        {{ user.fullname }}
+    </a>
+</li>
 {% endblock %}
 
 {% block toolbar %}

--- a/udata_front/theme/gouvfr/templates/user/datasets.html
+++ b/udata_front/theme/gouvfr/templates/user/datasets.html
@@ -2,12 +2,12 @@
 
 
 {% block breadcrumb %}
-    {{ super() }}
-    <li class="active" aria-current="page">
-        <a href="{{ url_for('users.datasets', user=user) }}">
-        {{ _('Datasets') }}
-        </a>
-    </li>
+{{ super() }}
+<li>
+	<a class="fr-breadcrumb__link" aria-current="page">
+		{{ _('Datasets') }}
+	</a>
+</li>
 {% endblock %}
 
 {% set user_tab = 'datasets' %}

--- a/udata_front/theme/gouvfr/templates/user/followers.html
+++ b/udata_front/theme/gouvfr/templates/user/followers.html
@@ -3,8 +3,12 @@
 {% set user_tab = 'followers' %}
 
 {% block breadcrumb %}
-    {{ super() }}
-    <li class="active" aria-current="page">{{ _('Followers') }}</li>
+{{ super() }}
+<li>
+    <a class="fr-breadcrumb__link" aria-current="page">
+        {{ _('Followers') }}
+    </a>
+</li>
 {% endblock %}
 
 {% block user_content %}

--- a/udata_front/theme/gouvfr/templates/user/following.html
+++ b/udata_front/theme/gouvfr/templates/user/following.html
@@ -3,8 +3,12 @@
 {% set user_tab = 'following' %}
 
 {% block breadcrumb %}
-    {{ super() }}
-    <li class="active" aria-current="page">{{ _('Following') }}</li>
+{{ super() }}
+<li>
+    <a class="fr-breadcrumb__link" aria-current="page">
+        {{ _('Following') }}
+    </a>
+</li>
 {% endblock %}
 
 {% block user_content %}

--- a/udata_front/theme/gouvfr/templates/user/list.html
+++ b/udata_front/theme/gouvfr/templates/user/list.html
@@ -11,13 +11,17 @@
 {% set bundle = 'search' %}
 
 {% block breadcrumb %}
-    <li class="active" aria-current="page">
+<li>
+    <a class="fr-breadcrumb__link" aria-current="page">
         {{ _('Users') }}
-        <small>{{ _('%(start)s to %(end)s on %(total)s',
-            start=users.page_start,
-            end=users.page_end,
-            total=users.total) }}</small>
-    </li>
+        <small>
+            {{ _('%(start)s to %(end)s on %(total)s',
+                start=users.page_start,
+                end=users.page_end,
+                total=users.total) }}
+        </small>
+    </a>
+</li>
 {% endblock %}
 
 {% block main_content %}

--- a/udata_front/theme/gouvfr/templates/user/reuses.html
+++ b/udata_front/theme/gouvfr/templates/user/reuses.html
@@ -2,12 +2,12 @@
 
 
 {% block breadcrumb %}
-    {{ super() }}
-    <li class="active" aria-current="page">
-        <a href="{{ url_for('users.reuses', user=user) }}">
-        {{ _('Reuses') }}
-        </a>
-    </li>
+{{ super() }}
+<li>
+	<a class="fr-breadcrumb__link" aria-current="page">
+		{{ _('Reuses') }}
+	</a>
+</li>
 {% endblock %}
 
 {% set user_tab = 'reuses' %}

--- a/udata_front/theme/gouvfr/translations/gouvfr.pot
+++ b/udata_front/theme/gouvfr/translations/gouvfr.pot
@@ -6,10 +6,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: udata-front 3.1.3.dev0\n"
+"Project-Id-Version: udata-front 3.1.4.dev0\n"
 "Report-Msgid-Bugs-To: data.gouv@data.gouv.fr\n"
-"POT-Creation-Date: 2023-02-28 11:01+0100\n"
-"PO-Revision-Date: 2023-02-28 11:01+0100\n"
+"POT-Creation-Date: 2023-03-08 15:35+0100\n"
+"PO-Revision-Date: 2023-03-08 15:35+0100\n"
 "Last-Translator: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
 "Language: en\n"
 "Language-Team: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
@@ -59,21 +59,21 @@ msgstr ""
 msgid "Transport"
 msgstr ""
 
-#: udata_front/frontend/helpers.py:164
+#: udata_front/frontend/helpers.py:165
 msgid "Anonymous user"
 msgstr ""
 
-#: udata_front/frontend/helpers.py:279
+#: udata_front/frontend/helpers.py:280
 msgctxt "month-format"
 msgid "yyyy/MM"
 msgstr ""
 
-#: udata_front/frontend/helpers.py:283
+#: udata_front/frontend/helpers.py:284
 msgctxt "day-format"
 msgid "yyyy/MM/dd"
 msgstr ""
 
-#: udata_front/frontend/helpers.py:302
+#: udata_front/frontend/helpers.py:303
 #, python-format
 msgid "%(start)s to %(end)s"
 msgstr ""
@@ -82,43 +82,43 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:46 udata_front/views/site.py:188
+#: udata_front/theme/gouvfr/__init__.py:46 udata_front/views/site.py:190
 msgid "Data"
 msgstr ""
 
 #: udata_front/theme/gouvfr/__init__.py:47
-#: udata_front/theme/gouvfr/templates/dataset/display.html:208
-#: udata_front/theme/gouvfr/templates/dataset/display.html:272
-#: udata_front/theme/gouvfr/templates/dataset/list.html:25
-#: udata_front/theme/gouvfr/templates/home.html:70
-#: udata_front/theme/gouvfr/templates/organization/display.html:61
-#: udata_front/theme/gouvfr/templates/organization/display.html:115
-#: udata_front/theme/gouvfr/templates/organization/list.html:28
+#: udata_front/theme/gouvfr/templates/dataset/display.html:216
+#: udata_front/theme/gouvfr/templates/dataset/display.html:280
+#: udata_front/theme/gouvfr/templates/dataset/list.html:27
+#: udata_front/theme/gouvfr/templates/home.html:78
+#: udata_front/theme/gouvfr/templates/organization/display.html:69
+#: udata_front/theme/gouvfr/templates/organization/display.html:123
+#: udata_front/theme/gouvfr/templates/organization/list.html:26
 #: udata_front/theme/gouvfr/templates/page.html:31
-#: udata_front/theme/gouvfr/templates/post/display.html:73
-#: udata_front/theme/gouvfr/templates/reuse/display.html:34
+#: udata_front/theme/gouvfr/templates/post/display.html:81
+#: udata_front/theme/gouvfr/templates/reuse/display.html:36
 #: udata_front/theme/gouvfr/templates/reuse/list.html:6
-#: udata_front/theme/gouvfr/templates/reuse/list.html:16
-#: udata_front/theme/gouvfr/templates/reuse/list.html:51
-#: udata_front/theme/gouvfr/templates/site/dashboard.html:22
+#: udata_front/theme/gouvfr/templates/reuse/list.html:17
+#: udata_front/theme/gouvfr/templates/reuse/list.html:49
+#: udata_front/theme/gouvfr/templates/site/dashboard.html:26
 #: udata_front/theme/gouvfr/templates/topic/browse.html:15
-#: udata_front/theme/gouvfr/templates/topic/reuses.html:19
-#: udata_front/theme/gouvfr/templates/user/following.html:16
+#: udata_front/theme/gouvfr/templates/topic/reuses.html:20
+#: udata_front/theme/gouvfr/templates/user/following.html:20
 #: udata_front/theme/gouvfr/templates/user/reuses.html:8
-#: udata_front/views/site.py:197
+#: udata_front/views/site.py:199
 msgid "Reuses"
 msgstr ""
 
 #: udata_front/theme/gouvfr/__init__.py:48
-#: udata_front/theme/gouvfr/templates/home.html:72
-#: udata_front/theme/gouvfr/templates/organization/display.html:21
+#: udata_front/theme/gouvfr/templates/home.html:80
+#: udata_front/theme/gouvfr/templates/organization/display.html:23
 #: udata_front/theme/gouvfr/templates/organization/list.html:6
-#: udata_front/theme/gouvfr/templates/organization/list.html:16
-#: udata_front/theme/gouvfr/templates/organization/list.html:33
-#: udata_front/theme/gouvfr/templates/site/dashboard.html:24
-#: udata_front/theme/gouvfr/templates/user/base.html:97
-#: udata_front/theme/gouvfr/templates/user/following.html:17
-#: udata_front/views/site.py:212
+#: udata_front/theme/gouvfr/templates/organization/list.html:17
+#: udata_front/theme/gouvfr/templates/organization/list.html:31
+#: udata_front/theme/gouvfr/templates/site/dashboard.html:28
+#: udata_front/theme/gouvfr/templates/user/base.html:105
+#: udata_front/theme/gouvfr/templates/user/following.html:21
+#: udata_front/views/site.py:214
 msgid "Organizations"
 msgstr ""
 
@@ -139,8 +139,8 @@ msgid "How to use data ?"
 msgstr ""
 
 #: udata_front/theme/gouvfr/__init__.py:66
-#: udata_front/theme/gouvfr/templates/home.html:47
-#: udata_front/theme/gouvfr/templates/post/display.html:17
+#: udata_front/theme/gouvfr/templates/home.html:55
+#: udata_front/theme/gouvfr/templates/post/display.html:19
 msgid "News"
 msgstr ""
 
@@ -202,7 +202,7 @@ msgid "Best reuse cases"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset-apis.html:3
-#: udata_front/views/dataset.py:146
+#: udata_front/views/dataset.py:145
 #, python-format
 msgid "%(num)d API"
 msgid_plural "%(num)d APIs"
@@ -213,7 +213,7 @@ msgstr[1] ""
 msgid "Download from "
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:110
+#: udata_front/theme/gouvfr/templates/dataset/display.html:118
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:177
 msgid "Producer"
 msgstr ""
@@ -232,13 +232,13 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:613
+#: udata_front/theme/gouvfr/templates/dataset/display.html:621
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:206
-#: udata_front/theme/gouvfr/templates/reuse/display.html:196
+#: udata_front/theme/gouvfr/templates/reuse/display.html:204
 msgid "Embed"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:552
+#: udata_front/theme/gouvfr/templates/dataset/display.html:560
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:209
 msgid "Temporal coverage"
 msgstr ""
@@ -255,7 +255,7 @@ msgstr ""
 msgid "Territory"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:547
+#: udata_front/theme/gouvfr/templates/dataset/display.html:555
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:232
 msgid "Frequency"
 msgstr ""
@@ -366,7 +366,7 @@ msgstr ""
 
 #: udata_front/theme/gouvfr/templates/header.html:115
 #: udata_front/theme/gouvfr/templates/security/register_user.html:11
-#: udata_front/theme/gouvfr/templates/security/register_user.html:57
+#: udata_front/theme/gouvfr/templates/security/register_user.html:62
 msgid "Sign up"
 msgstr ""
 
@@ -383,7 +383,7 @@ msgstr ""
 #: udata_front/theme/gouvfr/templates/api/oauth_error.html:12
 #: udata_front/theme/gouvfr/templates/errors/base.html:15
 #: udata_front/theme/gouvfr/templates/home.html:4
-#: udata_front/theme/gouvfr/templates/macros/breadcrumb.html:11
+#: udata_front/theme/gouvfr/templates/macros/breadcrumb.html:13
 #: udata_front/theme/gouvfr/templates/macros/metadata.html:2
 msgid "Home"
 msgstr ""
@@ -401,101 +401,101 @@ msgstr ""
 msgid "Open platform for French public data"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/home.html:41
+#: udata_front/theme/gouvfr/templates/home.html:49
 msgid "All featured topics"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/home.html:58
+#: udata_front/theme/gouvfr/templates/home.html:66
 msgid "All news"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:36
-#: udata_front/theme/gouvfr/templates/dataset/followers.html:4
-#: udata_front/theme/gouvfr/templates/dataset/list.html:8
-#: udata_front/theme/gouvfr/templates/dataset/list.html:13
-#: udata_front/theme/gouvfr/templates/dataset/list.html:32
-#: udata_front/theme/gouvfr/templates/home.html:68
-#: udata_front/theme/gouvfr/templates/home.html:109
-#: udata_front/theme/gouvfr/templates/organization/display.html:54
-#: udata_front/theme/gouvfr/templates/organization/display.html:98
+#: udata_front/theme/gouvfr/templates/dataset/display.html:38
+#: udata_front/theme/gouvfr/templates/dataset/followers.html:6
+#: udata_front/theme/gouvfr/templates/dataset/list.html:9
+#: udata_front/theme/gouvfr/templates/dataset/list.html:15
+#: udata_front/theme/gouvfr/templates/dataset/list.html:34
+#: udata_front/theme/gouvfr/templates/home.html:76
+#: udata_front/theme/gouvfr/templates/home.html:117
+#: udata_front/theme/gouvfr/templates/organization/display.html:62
+#: udata_front/theme/gouvfr/templates/organization/display.html:106
 #: udata_front/theme/gouvfr/templates/page.html:24
-#: udata_front/theme/gouvfr/templates/post/display.html:64
-#: udata_front/theme/gouvfr/templates/site/dashboard.html:20
+#: udata_front/theme/gouvfr/templates/post/display.html:72
+#: udata_front/theme/gouvfr/templates/site/dashboard.html:24
 #: udata_front/theme/gouvfr/templates/topic/browse.html:9
-#: udata_front/theme/gouvfr/templates/topic/datasets.html:19
+#: udata_front/theme/gouvfr/templates/topic/datasets.html:20
 #: udata_front/theme/gouvfr/templates/user/datasets.html:8
-#: udata_front/theme/gouvfr/templates/user/following.html:15
-#: udata_front/views/site.py:191
+#: udata_front/theme/gouvfr/templates/user/following.html:19
+#: udata_front/views/site.py:193
 msgid "Datasets"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/home.html:69
-#: udata_front/theme/gouvfr/templates/site/dashboard.html:21
-#: udata_front/views/site.py:203
+#: udata_front/theme/gouvfr/templates/home.html:77
+#: udata_front/theme/gouvfr/templates/site/dashboard.html:25
+#: udata_front/views/site.py:205
 msgid "Resources"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/home.html:71
-#: udata_front/theme/gouvfr/templates/site/dashboard.html:23
-#: udata_front/theme/gouvfr/templates/user/base.html:14
-#: udata_front/theme/gouvfr/templates/user/following.html:18
+#: udata_front/theme/gouvfr/templates/home.html:79
+#: udata_front/theme/gouvfr/templates/site/dashboard.html:27
+#: udata_front/theme/gouvfr/templates/user/base.html:16
+#: udata_front/theme/gouvfr/templates/user/following.html:22
 #: udata_front/theme/gouvfr/templates/user/list.html:5
-#: udata_front/theme/gouvfr/templates/user/list.html:15
-#: udata_front/views/site.py:218
+#: udata_front/theme/gouvfr/templates/user/list.html:16
+#: udata_front/views/site.py:220
 msgid "Users"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:222
-#: udata_front/theme/gouvfr/templates/dataset/display.html:282
-#: udata_front/theme/gouvfr/templates/home.html:73
-#: udata_front/theme/gouvfr/templates/reuse/display.html:237
-#: udata_front/theme/gouvfr/templates/site/dashboard.html:25
+#: udata_front/theme/gouvfr/templates/dataset/display.html:230
+#: udata_front/theme/gouvfr/templates/dataset/display.html:290
+#: udata_front/theme/gouvfr/templates/home.html:81
+#: udata_front/theme/gouvfr/templates/reuse/display.html:245
+#: udata_front/theme/gouvfr/templates/site/dashboard.html:29
 msgid "Discussions"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/home.html:81
+#: udata_front/theme/gouvfr/templates/home.html:89
 msgid "is"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/home.html:99
+#: udata_front/theme/gouvfr/templates/home.html:107
 #: udata_front/theme/gouvfr/templates/topic/display.html:28
 msgid "Featured datasets"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/home.html:100
+#: udata_front/theme/gouvfr/templates/home.html:108
 #: udata_front/theme/gouvfr/templates/topic/display.html:29
 msgid "Latest datasets"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/home.html:101
+#: udata_front/theme/gouvfr/templates/home.html:109
 msgid "Reference datasets"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/home.html:133
+#: udata_front/theme/gouvfr/templates/home.html:141
 #: udata_front/theme/gouvfr/templates/topic/display.html:65
 msgid "See more datasets"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/home.html:158
+#: udata_front/theme/gouvfr/templates/home.html:166
 msgid "Featured reuses"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/home.html:159
-#: udata_front/theme/gouvfr/templates/home.html:190
+#: udata_front/theme/gouvfr/templates/home.html:167
+#: udata_front/theme/gouvfr/templates/home.html:198
 #: udata_front/theme/gouvfr/templates/topic/display.html:11
 msgid "Latest reuses"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/home.html:167
+#: udata_front/theme/gouvfr/templates/home.html:175
 msgid "Data reuses"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/home.html:193
+#: udata_front/theme/gouvfr/templates/home.html:201
 msgid "See more reuses"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/metrics.html:4
-#: udata_front/theme/gouvfr/templates/metrics.html:10
+#: udata_front/theme/gouvfr/templates/metrics.html:11
 msgid "Metrics"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgstr ""
 msgid "metrics"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:612
-#: udata_front/theme/gouvfr/templates/organization/display.html:160
+#: udata_front/theme/gouvfr/templates/dataset/display.html:620
+#: udata_front/theme/gouvfr/templates/organization/display.html:168
 #: udata_front/theme/gouvfr/templates/page.html:44
-#: udata_front/theme/gouvfr/templates/post/display.html:87
-#: udata_front/theme/gouvfr/templates/reuse/display.html:124
+#: udata_front/theme/gouvfr/templates/post/display.html:95
+#: udata_front/theme/gouvfr/templates/reuse/display.html:132
 msgid "Actions"
 msgstr ""
 
@@ -546,9 +546,9 @@ msgid "Maintainer"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/api/admin.html:31
-#: udata_front/theme/gouvfr/templates/dataset/display.html:51
-#: udata_front/theme/gouvfr/templates/post/display.html:94
-#: udata_front/theme/gouvfr/templates/user/base.html:23
+#: udata_front/theme/gouvfr/templates/dataset/display.html:59
+#: udata_front/theme/gouvfr/templates/post/display.html:102
+#: udata_front/theme/gouvfr/templates/user/base.html:31
 msgid "Edit"
 msgstr ""
 
@@ -567,7 +567,7 @@ msgstr ""
 #: udata_front/theme/gouvfr/templates/api/card.html:9
 msgid ""
 "See on <a target=\"_blank\" rel=\"noopener\" title=\"See {title} on "
-"api.gouv.fr\" href=\"{url}\">api.gouv.fr</a>"
+"api.gouv.fr - opens a new window\" href=\"{url}\">api.gouv.fr</a>"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/api/card.html:18
@@ -624,16 +624,16 @@ msgstr ""
 #: udata_front/theme/gouvfr/templates/dataset/card-lg.html:10
 #: udata_front/theme/gouvfr/templates/dataset/card-sm.html:9
 #: udata_front/theme/gouvfr/templates/dataset/card-xs.html:10
-#: udata_front/theme/gouvfr/templates/dataset/display.html:69
+#: udata_front/theme/gouvfr/templates/dataset/display.html:77
 #: udata_front/theme/gouvfr/templates/reuse/card.html:11
-#: udata_front/theme/gouvfr/templates/reuse/display.html:48
+#: udata_front/theme/gouvfr/templates/reuse/display.html:56
 msgid "Private"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/card-lg.html:16
 #: udata_front/theme/gouvfr/templates/dataset/card-sm.html:15
 #: udata_front/theme/gouvfr/templates/dataset/card-xs.html:16
-#: udata_front/theme/gouvfr/templates/dataset/display.html:86
+#: udata_front/theme/gouvfr/templates/dataset/display.html:94
 msgid "Archived"
 msgstr ""
 
@@ -675,40 +675,40 @@ msgstr ""
 msgid "Explore with %(certifier)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:69
+#: udata_front/theme/gouvfr/templates/dataset/display.html:77
 msgid "This dataset is private and will not be visible by other users"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:76
+#: udata_front/theme/gouvfr/templates/dataset/display.html:84
 msgid "This dataset has been deleted. This will be permanent in the next 24 hours"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:76
+#: udata_front/theme/gouvfr/templates/dataset/display.html:84
 msgid "Deleted"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:81
+#: udata_front/theme/gouvfr/templates/dataset/display.html:89
 msgid ""
 "This dataset has been archived automatically because it has been deleted from"
 " the remote platform."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:83
+#: udata_front/theme/gouvfr/templates/dataset/display.html:91
 msgid "This dataset has been archived."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:98
-#: udata_front/theme/gouvfr/templates/organization/display.html:89
-#: udata_front/theme/gouvfr/templates/reuse/display.html:227
-#: udata_front/theme/gouvfr/templates/reuse/display.html:253
+#: udata_front/theme/gouvfr/templates/dataset/display.html:106
+#: udata_front/theme/gouvfr/templates/organization/display.html:97
+#: udata_front/theme/gouvfr/templates/reuse/display.html:235
+#: udata_front/theme/gouvfr/templates/reuse/display.html:261
 msgid "Description"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:115
+#: udata_front/theme/gouvfr/templates/dataset/display.html:123
 msgid "Author"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:120
+#: udata_front/theme/gouvfr/templates/dataset/display.html:128
 #, python-format
 msgid ""
 "This dataset has been published on the initiative and under the "
@@ -717,13 +717,13 @@ msgid ""
 "%(update)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:132
+#: udata_front/theme/gouvfr/templates/dataset/display.html:140
 msgid ""
 "This dataset come from an external portal.&nbsp;<a "
 "href='{external_source}'>View the original source.</a>"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:140
+#: udata_front/theme/gouvfr/templates/dataset/display.html:148
 msgid ""
 "This dataset is handled by the <a href='{geo_link}'>geo.data.gouv.fr</a> "
 "platform.\n"
@@ -733,147 +733,147 @@ msgid ""
 "geo.data.gouv.fr is available here.</a>"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:151
-#: udata_front/theme/gouvfr/templates/dataset/display.html:558
+#: udata_front/theme/gouvfr/templates/dataset/display.html:159
+#: udata_front/theme/gouvfr/templates/dataset/display.html:566
 msgid "Latest update"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:156
-#: udata_front/theme/gouvfr/templates/dataset/display.html:523
+#: udata_front/theme/gouvfr/templates/dataset/display.html:164
+#: udata_front/theme/gouvfr/templates/dataset/display.html:531
 msgid "License"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:174
-#: udata_front/theme/gouvfr/templates/dataset/display.html:254
+#: udata_front/theme/gouvfr/templates/dataset/display.html:182
+#: udata_front/theme/gouvfr/templates/dataset/display.html:262
 msgid "In-page navigation"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:190
-#: udata_front/theme/gouvfr/templates/dataset/display.html:262
+#: udata_front/theme/gouvfr/templates/dataset/display.html:198
+#: udata_front/theme/gouvfr/templates/dataset/display.html:270
 msgid "Files"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:236
-#: udata_front/theme/gouvfr/templates/dataset/display.html:292
+#: udata_front/theme/gouvfr/templates/dataset/display.html:244
+#: udata_front/theme/gouvfr/templates/dataset/display.html:300
 msgid "Community resources"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:250
-#: udata_front/theme/gouvfr/templates/dataset/display.html:302
-#: udata_front/theme/gouvfr/templates/dataset/display.html:504
-#: udata_front/theme/gouvfr/templates/reuse/display.html:153
+#: udata_front/theme/gouvfr/templates/dataset/display.html:258
+#: udata_front/theme/gouvfr/templates/dataset/display.html:310
+#: udata_front/theme/gouvfr/templates/dataset/display.html:512
+#: udata_front/theme/gouvfr/templates/reuse/display.html:161
 msgid "Informations"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:341
+#: udata_front/theme/gouvfr/templates/dataset/display.html:349
 #, python-format
 msgid "See the %(nb)d resources of type %(type)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:349
+#: udata_front/theme/gouvfr/templates/dataset/display.html:357
 msgid "There is no resources for this dataset yet."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:356
+#: udata_front/theme/gouvfr/templates/dataset/display.html:364
 msgid "Add a resource"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:376
+#: udata_front/theme/gouvfr/templates/dataset/display.html:384
 #, python-format
 msgid "%(num)d Reuse"
 msgid_plural "%(num)d Reuses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:381
-#: udata_front/theme/gouvfr/templates/reuse/display.html:187
+#: udata_front/theme/gouvfr/templates/dataset/display.html:389
+#: udata_front/theme/gouvfr/templates/reuse/display.html:195
 msgid "Add a reuse"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:398
+#: udata_front/theme/gouvfr/templates/dataset/display.html:406
 msgid "There is no reuses for this dataset yet."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:405
+#: udata_front/theme/gouvfr/templates/dataset/display.html:413
 #: udata_front/theme/gouvfr/templates/participez/participez.html:30
 msgid "Publish a reuse"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:411
+#: udata_front/theme/gouvfr/templates/dataset/display.html:419
 msgid "What's a reuse ?"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:430
+#: udata_front/theme/gouvfr/templates/dataset/display.html:438
 msgid "There is no discussions for this dataset yet."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:454
+#: udata_front/theme/gouvfr/templates/dataset/display.html:462
 msgid ""
 "These resources are published by the community and the producer isn't "
 "responsible for them."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:461
+#: udata_front/theme/gouvfr/templates/dataset/display.html:469
 #, python-format
 msgid "%(num)d Community resource"
 msgid_plural "%(num)d Community resources"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:476
+#: udata_front/theme/gouvfr/templates/dataset/display.html:484
 msgid "There is no community resources for this dataset yet."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:483
+#: udata_front/theme/gouvfr/templates/dataset/display.html:491
 msgid "Share your resources"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:489
+#: udata_front/theme/gouvfr/templates/dataset/display.html:497
 msgid "Learn more about the community"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:505
+#: udata_front/theme/gouvfr/templates/dataset/display.html:513
 msgid "Tags"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:531
-#: udata_front/theme/gouvfr/templates/reuse/display.html:165
+#: udata_front/theme/gouvfr/templates/dataset/display.html:539
+#: udata_front/theme/gouvfr/templates/reuse/display.html:173
 msgid "ID"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:535
+#: udata_front/theme/gouvfr/templates/dataset/display.html:543
 msgid "Remote source"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:541
+#: udata_front/theme/gouvfr/templates/dataset/display.html:549
 msgid "Temporality"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:543
+#: udata_front/theme/gouvfr/templates/dataset/display.html:551
 msgid "Creation"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:564
+#: udata_front/theme/gouvfr/templates/dataset/display.html:572
 msgid "Spatial coverage"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:567
+#: udata_front/theme/gouvfr/templates/dataset/display.html:575
 msgid "Territorial coverage"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:574
+#: udata_front/theme/gouvfr/templates/dataset/display.html:582
 msgid "Territorial coverage granularity"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:583
+#: udata_front/theme/gouvfr/templates/dataset/display.html:591
 msgid "Data schema"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:588
+#: udata_front/theme/gouvfr/templates/dataset/display.html:596
 msgid "The dataset files are following the schema: "
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:594
+#: udata_front/theme/gouvfr/templates/dataset/display.html:602
 msgid ""
 "Schemas allow to describe data models,\n"
 "                                discover how schemas improve your data "
@@ -881,50 +881,50 @@ msgid ""
 "                                on <a href=\"{url}\">schema.data.gouv.fr</a>"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:605
+#: udata_front/theme/gouvfr/templates/dataset/display.html:613
 #: udata_front/theme/gouvfr/templates/dataset/resource/card.html:132
 msgid "See schema documentation"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:618
+#: udata_front/theme/gouvfr/templates/dataset/display.html:626
 msgid "Extras"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:627
+#: udata_front/theme/gouvfr/templates/dataset/display.html:635
 msgid "See extras"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:646
+#: udata_front/theme/gouvfr/templates/dataset/display.html:654
 msgid "Harvest"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:655
+#: udata_front/theme/gouvfr/templates/dataset/display.html:663
 msgid "See harvest extras"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/followers.html:6
-#: udata_front/theme/gouvfr/templates/dataset/list.html:24
-#: udata_front/theme/gouvfr/templates/organization/list.html:27
-#: udata_front/theme/gouvfr/templates/reuse/list.html:46
-#: udata_front/theme/gouvfr/templates/user/followers.html:7
+#: udata_front/theme/gouvfr/templates/dataset/followers.html:16
+#: udata_front/theme/gouvfr/templates/dataset/list.html:26
+#: udata_front/theme/gouvfr/templates/organization/list.html:25
+#: udata_front/theme/gouvfr/templates/reuse/list.html:44
+#: udata_front/theme/gouvfr/templates/user/followers.html:9
 msgid "Followers"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/followers.html:13
-#: udata_front/theme/gouvfr/templates/user/base.html:72
-#: udata_front/theme/gouvfr/templates/user/followers.html:12
+#: udata_front/theme/gouvfr/templates/dataset/followers.html:25
+#: udata_front/theme/gouvfr/templates/user/base.html:80
+#: udata_front/theme/gouvfr/templates/user/followers.html:16
 #, python-format
 msgid "%(num)d follower"
 msgid_plural "%(num)d followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/dataset/list.html:14
+#: udata_front/theme/gouvfr/templates/dataset/list.html:16
 #, python-format
 msgid "%(site)s dataset search"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/list.html:15
+#: udata_front/theme/gouvfr/templates/dataset/list.html:17
 #: udata_front/theme/gouvfr/templates/organization/list.html:8
 #: udata_front/theme/gouvfr/templates/reuse/list.html:8
 #: udata_front/theme/gouvfr/templates/topic/datasets.html:8
@@ -933,57 +933,57 @@ msgstr ""
 msgid "search"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/list.html:15
+#: udata_front/theme/gouvfr/templates/dataset/list.html:17
 #: udata_front/theme/gouvfr/templates/organization/producer-summary.html:42
 #: udata_front/theme/gouvfr/templates/topic/datasets.html:8
 msgid "datasets"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/list.html:22
-#: udata_front/theme/gouvfr/templates/organization/list.html:25
-#: udata_front/theme/gouvfr/templates/reuse/list.html:44
+#: udata_front/theme/gouvfr/templates/dataset/list.html:24
+#: udata_front/theme/gouvfr/templates/organization/list.html:23
+#: udata_front/theme/gouvfr/templates/reuse/list.html:42
 msgid "Newest"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/list.html:23
-#: udata_front/theme/gouvfr/templates/organization/list.html:26
-#: udata_front/theme/gouvfr/templates/reuse/list.html:45
+#: udata_front/theme/gouvfr/templates/dataset/list.html:25
+#: udata_front/theme/gouvfr/templates/organization/list.html:24
+#: udata_front/theme/gouvfr/templates/reuse/list.html:43
 msgid "Oldest"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/list.html:34
+#: udata_front/theme/gouvfr/templates/dataset/list.html:36
 #, python-format
 msgid "Search among %(count)s datasets on %(site)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/list.html:40
+#: udata_front/theme/gouvfr/templates/dataset/list.html:42
 msgid "Search reuses"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/list.html:53
+#: udata_front/theme/gouvfr/templates/dataset/list.html:55
 msgid "Search for dataset"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/list.html:55
-#: udata_front/theme/gouvfr/templates/dataset/list.html:60
-#: udata_front/theme/gouvfr/templates/organization/list.html:39
-#: udata_front/theme/gouvfr/templates/organization/list.html:44
-#: udata_front/theme/gouvfr/templates/reuse/list.html:64
-#: udata_front/theme/gouvfr/templates/reuse/list.html:69
+#: udata_front/theme/gouvfr/templates/dataset/list.html:57
+#: udata_front/theme/gouvfr/templates/dataset/list.html:62
+#: udata_front/theme/gouvfr/templates/organization/list.html:37
+#: udata_front/theme/gouvfr/templates/organization/list.html:42
+#: udata_front/theme/gouvfr/templates/reuse/list.html:62
+#: udata_front/theme/gouvfr/templates/reuse/list.html:67
 msgid "Search..."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/list.html:66
+#: udata_front/theme/gouvfr/templates/dataset/list.html:68
 #: udata_front/theme/gouvfr/templates/macros/search.html:224
-#: udata_front/theme/gouvfr/templates/organization/list.html:50
+#: udata_front/theme/gouvfr/templates/organization/list.html:48
 #: udata_front/theme/gouvfr/templates/post/subnav.html:13
-#: udata_front/theme/gouvfr/templates/reuse/list.html:75
+#: udata_front/theme/gouvfr/templates/reuse/list.html:73
 msgid "Search"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/list.html:70
-#: udata_front/theme/gouvfr/templates/organization/list.html:54
-#: udata_front/theme/gouvfr/templates/reuse/list.html:103
+#: udata_front/theme/gouvfr/templates/dataset/list.html:72
+#: udata_front/theme/gouvfr/templates/organization/list.html:52
+#: udata_front/theme/gouvfr/templates/reuse/list.html:101
 #, python-format
 msgid "%(result)s results"
 msgstr ""
@@ -1005,7 +1005,7 @@ msgid "Unavailable"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/resource/card.html:53
-msgid "Resource link"
+msgid "Resource link - opens a new window"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/resource/card.html:63
@@ -1017,7 +1017,7 @@ msgid "URL"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/resource/card.html:83
-#: udata_front/theme/gouvfr/templates/reuse/display.html:198
+#: udata_front/theme/gouvfr/templates/reuse/display.html:206
 msgid "Permalink"
 msgstr ""
 
@@ -1092,8 +1092,12 @@ msgstr ""
 msgid "Following since %(date)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/macros/breadcrumb.html:6
+#: udata_front/theme/gouvfr/templates/macros/breadcrumb.html:7
 msgid "You're here:"
+msgstr ""
+
+#: udata_front/theme/gouvfr/templates/macros/breadcrumb.html:8
+msgid "See breadcrumbs"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/certified.html:3
@@ -1102,7 +1106,7 @@ msgid "The identity of this public service is certified by %(certifier)s"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/integrate.html:16
-#: udata_front/theme/gouvfr/templates/reuse/display.html:212
+#: udata_front/theme/gouvfr/templates/reuse/display.html:220
 msgid "Copy this"
 msgstr ""
 
@@ -1209,7 +1213,11 @@ msgstr ""
 msgid "Spatial coverage not set"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/macros/quality_score_tooltip.html:59
+#: udata_front/theme/gouvfr/templates/macros/quality_score_tooltip.html:58
+msgid "Learn more about this indicator - opens a new window"
+msgstr ""
+
+#: udata_front/theme/gouvfr/templates/macros/quality_score_tooltip.html:60
 msgid "Learn more about this indicator"
 msgstr ""
 
@@ -1413,7 +1421,7 @@ msgid "A new reuse of your dataset %(dataset)s has been published"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/mail/new_reuse.html:31
-#: udata_front/theme/gouvfr/templates/reuse/display.html:99
+#: udata_front/theme/gouvfr/templates/reuse/display.html:107
 msgid "See the reuse"
 msgstr ""
 
@@ -1503,50 +1511,50 @@ msgstr[1] ""
 msgid "organization"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:31
+#: udata_front/theme/gouvfr/templates/organization/display.html:39
 msgid ""
 "This organization has been deleted. This will be permanent in the next 24 "
 "hours"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:75
-#: udata_front/theme/gouvfr/templates/organization/display.html:81
+#: udata_front/theme/gouvfr/templates/organization/display.html:83
+#: udata_front/theme/gouvfr/templates/organization/display.html:89
 msgid "Modify organization"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:108
+#: udata_front/theme/gouvfr/templates/organization/display.html:116
 #, python-format
 msgid "See the dataset"
 msgid_plural "See %(num)d datasets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:127
+#: udata_front/theme/gouvfr/templates/organization/display.html:135
 msgid "Members"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:143
+#: udata_front/theme/gouvfr/templates/organization/display.html:151
 msgid "Technical details"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:150
-#: udata_front/theme/gouvfr/templates/reuse/display.html:174
+#: udata_front/theme/gouvfr/templates/organization/display.html:158
+#: udata_front/theme/gouvfr/templates/reuse/display.html:182
 msgid "Creation date"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:154
+#: udata_front/theme/gouvfr/templates/organization/display.html:162
 msgid "Modification date"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:168
+#: udata_front/theme/gouvfr/templates/organization/display.html:176
 msgid "Modify information"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:177
+#: udata_front/theme/gouvfr/templates/organization/display.html:185
 msgid "Download list of datasets as csv file"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:191
+#: udata_front/theme/gouvfr/templates/organization/display.html:199
 msgid "Pending request to join this organization"
 msgstr ""
 
@@ -1559,22 +1567,12 @@ msgstr ""
 msgid "organizations"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/list.html:17
-#: udata_front/theme/gouvfr/templates/post/list.html:16
-#: udata_front/theme/gouvfr/templates/reuse/list.html:17
-#: udata_front/theme/gouvfr/templates/topic/datasets.html:20
-#: udata_front/theme/gouvfr/templates/topic/reuses.html:20
-#: udata_front/theme/gouvfr/templates/user/list.html:16
-#, python-format
-msgid "%(start)s to %(end)s on %(total)s"
-msgstr ""
-
-#: udata_front/theme/gouvfr/templates/organization/list.html:34
+#: udata_front/theme/gouvfr/templates/organization/list.html:32
 #, python-format
 msgid "Search among %(count)s organizations on %(site)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/list.html:37
+#: udata_front/theme/gouvfr/templates/organization/list.html:35
 msgid "Search an organization"
 msgstr ""
 
@@ -1585,7 +1583,7 @@ msgid "reuses"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/participez/participez.html:5
-#: udata_front/theme/gouvfr/templates/reuse/display.html:184
+#: udata_front/theme/gouvfr/templates/reuse/display.html:192
 msgid "Participate"
 msgstr ""
 
@@ -1601,40 +1599,40 @@ msgstr ""
 msgid "Publish a dataset"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/post/display.html:27
+#: udata_front/theme/gouvfr/templates/post/display.html:35
 #: udata_front/theme/gouvfr/templates/reuse/card.html:18
-#: udata_front/theme/gouvfr/templates/reuse/display.html:63
+#: udata_front/theme/gouvfr/templates/reuse/display.html:71
 #, python-format
 msgid "Published on %(date)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/post/display.html:31
+#: udata_front/theme/gouvfr/templates/post/display.html:39
 msgid "This post is a draft and will not be visible by other users"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/post/display.html:36
+#: udata_front/theme/gouvfr/templates/post/display.html:44
 msgid "This post has been deleted. This will be permanent in the next 24 hours"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/post/display.html:106
+#: udata_front/theme/gouvfr/templates/post/display.html:114
 msgid "Navigate in the post collection"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/post/display.html:115
+#: udata_front/theme/gouvfr/templates/post/display.html:123
 msgid "Previous post"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/post/display.html:121
+#: udata_front/theme/gouvfr/templates/post/display.html:129
 msgid "All posts"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/post/display.html:130
+#: udata_front/theme/gouvfr/templates/post/display.html:138
 msgid "Next post"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/post/list.html:5
-#: udata_front/theme/gouvfr/templates/post/list.html:15
-#: udata_front/theme/gouvfr/templates/post/list.html:25
+#: udata_front/theme/gouvfr/templates/post/list.html:16
+#: udata_front/theme/gouvfr/templates/post/list.html:23
 msgid "Posts"
 msgstr ""
 
@@ -1647,11 +1645,11 @@ msgstr ""
 msgid "posts"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/post/list.html:29
+#: udata_front/theme/gouvfr/templates/post/list.html:27
 msgid "To stay up-to-date, you can subscribe to"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/post/list.html:32
+#: udata_front/theme/gouvfr/templates/post/list.html:30
 msgid "our newsletter."
 msgstr ""
 
@@ -1671,70 +1669,70 @@ msgstr ""
 msgid "reuse"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:47
+#: udata_front/theme/gouvfr/templates/reuse/display.html:55
 msgid "This reuse is private and will not be visible by other users"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:53
+#: udata_front/theme/gouvfr/templates/reuse/display.html:61
 msgid "This reuse has been deleted. This will be permanent in the next 24 hours"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:73
-#: udata_front/theme/gouvfr/templates/reuse/display.html:79
+#: udata_front/theme/gouvfr/templates/reuse/display.html:81
+#: udata_front/theme/gouvfr/templates/reuse/display.html:87
 msgid "Modify reuse"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:108
+#: udata_front/theme/gouvfr/templates/reuse/display.html:116
 msgid "Reuse informations"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:112
+#: udata_front/theme/gouvfr/templates/reuse/display.html:120
 msgid "Reuser"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:118
+#: udata_front/theme/gouvfr/templates/reuse/display.html:126
 msgid "Metadata"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:155
+#: udata_front/theme/gouvfr/templates/reuse/display.html:163
 msgid "Type"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:160
+#: udata_front/theme/gouvfr/templates/reuse/display.html:168
 msgid "Topic"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:172
+#: udata_front/theme/gouvfr/templates/reuse/display.html:180
 msgid "Publication"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:192
+#: udata_front/theme/gouvfr/templates/reuse/display.html:200
 msgid "Contact the reuser"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:223
+#: udata_front/theme/gouvfr/templates/reuse/display.html:231
 msgid "Summary"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:232
-#: udata_front/theme/gouvfr/templates/reuse/display.html:262
+#: udata_front/theme/gouvfr/templates/reuse/display.html:240
+#: udata_front/theme/gouvfr/templates/reuse/display.html:270
 msgid "Used datasets"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:242
-#: udata_front/theme/gouvfr/templates/reuse/display.html:283
+#: udata_front/theme/gouvfr/templates/reuse/display.html:250
+#: udata_front/theme/gouvfr/templates/reuse/display.html:291
 msgid "More reuses"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:275
+#: udata_front/theme/gouvfr/templates/reuse/display.html:283
 msgid "Discussion between the organization and the community about this reuse."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:277
+#: udata_front/theme/gouvfr/templates/reuse/display.html:285
 msgid "Discussion between the owner and the community about this reuse."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:284
+#: udata_front/theme/gouvfr/templates/reuse/display.html:292
 msgid "Discover more reuses."
 msgstr ""
 
@@ -1743,80 +1741,80 @@ msgstr ""
 msgid "%(site)s reuse search"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/list.html:26
+#: udata_front/theme/gouvfr/templates/reuse/list.html:24
 msgid "Health"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/list.html:27
+#: udata_front/theme/gouvfr/templates/reuse/list.html:25
 msgid "Transport and mobility"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/list.html:28
+#: udata_front/theme/gouvfr/templates/reuse/list.html:26
 msgid "Housing and development"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/list.html:29
+#: udata_front/theme/gouvfr/templates/reuse/list.html:27
 msgid "Food and agriculture"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/list.html:30
+#: udata_front/theme/gouvfr/templates/reuse/list.html:28
 msgid "Culture and recreation"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/list.html:31
+#: udata_front/theme/gouvfr/templates/reuse/list.html:29
 msgid "Economy and business"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/list.html:32
+#: udata_front/theme/gouvfr/templates/reuse/list.html:30
 msgid "Environment and energy"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/list.html:33
+#: udata_front/theme/gouvfr/templates/reuse/list.html:31
 msgid "Work and training"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/list.html:34
+#: udata_front/theme/gouvfr/templates/reuse/list.html:32
 msgid "Politics and public life"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/list.html:35
+#: udata_front/theme/gouvfr/templates/reuse/list.html:33
 msgid "Safety and security"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/list.html:36
+#: udata_front/theme/gouvfr/templates/reuse/list.html:34
 msgid "Education and research"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/list.html:37
+#: udata_front/theme/gouvfr/templates/reuse/list.html:35
 msgid "Society and demography"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/list.html:38
+#: udata_front/theme/gouvfr/templates/reuse/list.html:36
 msgid "Law and justice"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/list.html:39
+#: udata_front/theme/gouvfr/templates/reuse/list.html:37
 msgid "Open data tools"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/list.html:40
+#: udata_front/theme/gouvfr/templates/reuse/list.html:38
 msgid "Others"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/list.html:53
+#: udata_front/theme/gouvfr/templates/reuse/list.html:51
 #, python-format
 msgid "Search among %(count)s reuses on %(site)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/list.html:57
+#: udata_front/theme/gouvfr/templates/reuse/list.html:55
 msgid "Search in datasets"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/list.html:62
+#: udata_front/theme/gouvfr/templates/reuse/list.html:60
 msgid "Search a reuse"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/list.html:86
+#: udata_front/theme/gouvfr/templates/reuse/list.html:84
 msgid "All"
 msgstr ""
 
@@ -1833,7 +1831,7 @@ msgstr ""
 #: udata_front/theme/gouvfr/templates/security/change_password.html:15
 #: udata_front/theme/gouvfr/templates/security/forgot_password.html:15
 #: udata_front/theme/gouvfr/templates/security/login_user.html:14
-#: udata_front/theme/gouvfr/templates/security/register_user.html:18
+#: udata_front/theme/gouvfr/templates/security/register_user.html:23
 #: udata_front/theme/gouvfr/templates/security/reset_password.html:13
 #: udata_front/theme/gouvfr/templates/security/send_confirmation.html:12
 msgid ""
@@ -1889,22 +1887,26 @@ msgstr ""
 msgid "Create an account"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/security/register_user.html:14
+#: udata_front/theme/gouvfr/templates/security/register_user.html:17
+msgid "Why create an account? - opens a new window"
+msgstr ""
+
+#: udata_front/theme/gouvfr/templates/security/register_user.html:19
 msgid "Why create an account?"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/security/register_user.html:24
+#: udata_front/theme/gouvfr/templates/security/register_user.html:29
 msgid "Javascript is required to sign up."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/security/register_user.html:36
+#: udata_front/theme/gouvfr/templates/security/register_user.html:41
 #, python-format
 msgid ""
 "I have read and accept <a href=\"%(url)s\"> the terms and conditions of the "
 "service.</a>"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/security/register_user.html:43
+#: udata_front/theme/gouvfr/templates/security/register_user.html:48
 msgid "Retype the characters from the picture"
 msgstr ""
 
@@ -1917,7 +1919,7 @@ msgid "Submit"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/site/dashboard.html:4
-#: udata_front/theme/gouvfr/templates/site/dashboard.html:14
+#: udata_front/theme/gouvfr/templates/site/dashboard.html:16
 msgid "Dashboard"
 msgstr ""
 
@@ -1929,7 +1931,7 @@ msgstr ""
 msgid "activity"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/site/dashboard.html:47
+#: udata_front/theme/gouvfr/templates/site/dashboard.html:51
 msgid "Community activity"
 msgstr ""
 
@@ -2094,6 +2096,13 @@ msgstr ""
 msgid "topic"
 msgstr ""
 
+#: udata_front/theme/gouvfr/templates/topic/datasets.html:22
+#: udata_front/theme/gouvfr/templates/topic/reuses.html:22
+#: udata_front/theme/gouvfr/templates/user/list.html:18
+#, python-format
+msgid "%(start)s to %(end)s on %(total)s"
+msgstr ""
+
 #: udata_front/theme/gouvfr/templates/topic/reuses.html:6
 #, python-format
 msgid "%(topic)s reuses"
@@ -2104,8 +2113,8 @@ msgstr ""
 msgid "%(site)s %(topic)s related reuses"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/user/activity.html:5
-#: udata_front/theme/gouvfr/templates/user/base.html:67
+#: udata_front/theme/gouvfr/templates/user/activity.html:7
+#: udata_front/theme/gouvfr/templates/user/base.html:75
 msgid "Activity"
 msgstr ""
 
@@ -2122,36 +2131,36 @@ msgstr ""
 msgid "profile"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/user/base.html:38
+#: udata_front/theme/gouvfr/templates/user/base.html:46
 msgid "Work in progress"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/user/base.html:39
+#: udata_front/theme/gouvfr/templates/user/base.html:47
 msgid "The user page is currently being renovated to improve user experience."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/user/base.html:78
+#: udata_front/theme/gouvfr/templates/user/base.html:86
 #, python-format
 msgid "%(num)d followed"
 msgid_plural "%(num)d followed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/user/base.html:84
+#: udata_front/theme/gouvfr/templates/user/base.html:92
 #, python-format
 msgid "%(num)d dataset"
 msgid_plural "%(num)d datasets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/user/base.html:90
+#: udata_front/theme/gouvfr/templates/user/base.html:98
 #, python-format
 msgid "%(num)d reuse"
 msgid_plural "%(num)d reuses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/user/base.html:108
+#: udata_front/theme/gouvfr/templates/user/base.html:116
 msgid "User's admin profile"
 msgstr ""
 
@@ -2160,44 +2169,44 @@ msgstr ""
 msgid "%(user)s has not yet published any dataset"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/user/followers.html:31
+#: udata_front/theme/gouvfr/templates/user/followers.html:35
 #, python-format
 msgid "%(user)s has no follower"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/user/following.html:7
+#: udata_front/theme/gouvfr/templates/user/following.html:9
 msgid "Following"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/user/following.html:41
+#: udata_front/theme/gouvfr/templates/user/following.html:45
 #, python-format
 msgid "Follow %(num)d dataset"
 msgid_plural "Follow %(num)d datasets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/user/following.html:61
+#: udata_front/theme/gouvfr/templates/user/following.html:65
 #, python-format
 msgid "Follow %(num)d reuse"
 msgid_plural "Follow %(num)d reuses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/user/following.html:81
+#: udata_front/theme/gouvfr/templates/user/following.html:85
 #, python-format
 msgid "Follow %(num)d organization"
 msgid_plural "Follow %(num)d organizations"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/user/following.html:101
+#: udata_front/theme/gouvfr/templates/user/following.html:105
 #, python-format
 msgid "Follow %(num)d user"
 msgid_plural "Follow %(num)d users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/user/following.html:127
+#: udata_front/theme/gouvfr/templates/user/following.html:131
 #, python-format
 msgid "%(user)s is not following anyone"
 msgstr ""
@@ -2220,35 +2229,35 @@ msgstr ""
 msgid "Last datasets"
 msgstr ""
 
-#: udata_front/views/dataset.py:139
+#: udata_front/views/dataset.py:138
 #, python-format
 msgid "%(num)d Main file"
 msgid_plural "%(num)d Main files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/views/dataset.py:143
+#: udata_front/views/dataset.py:142
 #, python-format
 msgid "%(num)d Documentation"
 msgid_plural "%(num)d Documentations"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/views/dataset.py:145
+#: udata_front/views/dataset.py:144
 #, python-format
 msgid "%(num)d Update"
 msgid_plural "%(num)d Updates"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/views/dataset.py:150
+#: udata_front/views/dataset.py:149
 #, python-format
 msgid "%(num)d Code repository"
 msgid_plural "%(num)d Code repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/views/dataset.py:152
+#: udata_front/views/dataset.py:151
 #, python-format
 msgid "%(num)d Other"
 msgid_plural "%(num)d Others"
@@ -2263,7 +2272,7 @@ msgstr ""
 msgid "Transfer"
 msgstr ""
 
-#: udata_front/views/site.py:209
+#: udata_front/views/site.py:211
 msgid "Community"
 msgstr ""
 


### PR DESCRIPTION
Close https://github.com/etalab/data.gouv.fr/issues/813

It removes some lists and add some new ones.
It also uses the DSFR breadcrumb and reduce the discrepancy between udata-front and the DSFR.
This implies a small visual change in the top of the pages but works better in responsive. We can overwrite it if we really want but I don't think it's worth it.