### PR TITLE
Fix links color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - fix RGAA criterion 9.3 [#222](https://github.com/etalab/udata-front/pull/222)
 - New reuse page [#210](https://github.com/etalab/udata-front/pull/210)
 - Fix [dependabot/10](https://github.com/etalab/udata-front/security/dependabot/10) [#228](https://github.com/etalab/udata-front/pull/228)
+- Fix links color [#232](https://github.com/etalab/udata-front/pull/232)
 
 ## 3.2.0 (2023-03-07)
 

--- a/theme/js/components/dataset/card-lg.vue
+++ b/theme/js/components/dataset/card-lg.vue
@@ -42,7 +42,7 @@
         <p class="fr-m-0 fr-text--sm" v-if="organization || owner">
           {{ $t('From') }}
           <span class="not-enlarged" v-if="organization">
-            <a :href="organization.page">
+            <a class="fr-link" :href="organization.page">
               <OrganizationNameWithCertificate :organization="organization" />
             </a>
           </span>

--- a/theme/js/components/dataset/resource/resource.vue
+++ b/theme/js/components/dataset/resource/resource.vue
@@ -35,7 +35,7 @@
           </div>
           <p class="fr-mb-0 fr-mt-1v fr-text--xs text-grey-380" v-if="isCommunityResource && (resource.organization || resource.owner)">
             {{ $t('From') }}
-            <a :href="resource.organization.page" v-if="resource.organization">
+            <a class="fr-link" :href="resource.organization.page" v-if="resource.organization">
               <OrganizationNameWithCertificate :organization="resource.organization" />
             </a>
             <template v-else-if="owner">{{owner}}</template>

--- a/theme/js/components/discussions/thread-reply.vue
+++ b/theme/js/components/discussions/thread-reply.vue
@@ -3,7 +3,7 @@
     <div class="fr-grid-row fr-grid-row--middle fr-mb-3v">
       <h4 class="fr-col fr-text--bold fr-mb-0">{{ $t("Reply to the discussion") }}</h4>
       <div class="fr-col-auto">
-        <button class="fr-link--close fr-link text-grey-500 fr-mr-0" @click="$emit('close')">
+        <button class="fr-btn--close fr-btn text-grey-500 fr-mr-0" @click="$emit('close')">
           {{$t('Close')}}
         </button>
       </div>

--- a/theme/js/components/discussions/threads-create.vue
+++ b/theme/js/components/discussions/threads-create.vue
@@ -8,7 +8,7 @@
       <div class="fr-grid-row fr-grid-row--middle fr-py-2w fr-px-3w">
         <div class="fr-col fr-h6 fr-mb-0">{{ $t("New discussion") }}</div>
         <div>
-          <button class="fr-link--close fr-link text-grey-500 fr-mr-0" @click="hideForm">
+          <button class="fr-btn--close fr-btn text-grey-500 fr-mr-0" @click="hideForm">
             {{$t('Close')}}
           </button>
         </div>

--- a/theme/js/components/discussions/threads.vue
+++ b/theme/js/components/discussions/threads.vue
@@ -54,7 +54,7 @@ Discussions allow users to interact with others.
               {{
                 $t("You are seeing a specific discussion about this dataset")
               }}
-              <button class="fr-link--close fr-link fr-mr-0" @click.prevent="viewAllDiscussions">
+              <button class="fr-btn--close fr-btn fr-mr-0" @click.prevent="viewAllDiscussions">
                 {{$t('Close')}}
               </button>
             </div>

--- a/theme/less/components/markdown.less
+++ b/theme/less/components/markdown.less
@@ -108,17 +108,21 @@ Content on the site can be styled with Markdown. Ready made styles are provided 
         max-width: 100%;
     }
 
-    //They are indeed supported !
+    a {
+        .fr-link;
+    }
+
+    // They are indeed supported !
     table {
         width: 100%;
         border-spacing: 0;
-        border-collapse: separate; //Needed for rounded borders
+        border-collapse: separate; // Needed for rounded borders
 
         margin: @spacing-md 0;
 
         .rounded-xxs;
 
-        //This below is way too complicated just for some borders. But it works®
+        // This below is way too complicated just for some borders. But it works®
         thead {
             background: @grey-50;
 

--- a/theme/less/content/links.less
+++ b/theme/less/content/links.less
@@ -126,6 +126,7 @@ a {
 
 .fr-link {
     --text-action-high-blue-france: @blue-400;
+    display: inline;
 }
 
 .fr-link.rounded-0 {

--- a/udata_front/theme/gouvfr/templates/dataset/card-lg.html
+++ b/udata_front/theme/gouvfr/templates/dataset/card-lg.html
@@ -60,7 +60,7 @@
                 {{ _('From') }}
                 {% if dataset.organization %}
                     <span class="not-enlarged">
-                        <a href="{{ url_for('organizations.show', org=dataset.organization) }}">
+                        <a class="fr-link" href="{{ url_for('organizations.show', org=dataset.organization) }}">
                             {{organization_name_with_certificate(dataset.organization)}}
                         </a>
                     </span>

--- a/udata_front/theme/gouvfr/templates/dataset/card-sm.html
+++ b/udata_front/theme/gouvfr/templates/dataset/card-sm.html
@@ -59,7 +59,7 @@
                 {{ _('From') }}
                 {% if dataset.organization %}
                 <span class="not-enlarged">
-                    <a href="{{ url_for('organizations.show', org=dataset.organization) }}">
+                    <a class="fr-link" href="{{ url_for('organizations.show', org=dataset.organization) }}">
                         {{organization_name_with_certificate(dataset.organization)}}
                     </a>
                 </span>

--- a/udata_front/theme/gouvfr/templates/dataset/card-xs.html
+++ b/udata_front/theme/gouvfr/templates/dataset/card-xs.html
@@ -60,9 +60,10 @@
                 {{ _('From') }}
                 {% if dataset.organization %}
                 <span class="not-enlarged">
-                    <a href="{{ url_for('organizations.show', org=dataset.organization) }}">
-                        {{organization_name_with_certificate(dataset.organization)}}
-                    </a>
+                    <a
+                        class="fr-link"
+                        href="{{ url_for('organizations.show', org=dataset.organization) }}"
+                    >{{organization_name_with_certificate(dataset.organization)}}</a>
                 </span>
                 {% elif dataset.owner %}
                 {{owner_name(dataset)}}

--- a/udata_front/theme/gouvfr/templates/header.html
+++ b/udata_front/theme/gouvfr/templates/header.html
@@ -62,10 +62,10 @@
                 </div>
                 <div class="fr-header__tools">
                     <div class="fr-header__tools-links">
-                        <ul class="fr-links-group">
+                        <ul class="fr-btns-group">
                             {% if current_user.is_authenticated %}
                                 <li>
-                                    <div class="fr-link fr-icon-svg fr-icon--sm fr-grid-row text-grey-500">
+                                    <div class="fr-btn fr-icon-svg fr-icon--sm fr-grid-row text-grey-500">
                                         <img
                                             src="{{ current_user|avatar_url(24) }}"
                                             width="24"
@@ -80,7 +80,7 @@
                                 <li>
                                     <a
                                         href="{{ url_for('admin.index') }}"
-                                        class="fr-link fr-icon-svg fr-icon--sm"
+                                        class="fr-btn fr-icon-svg fr-icon--sm"
                                     >
                                         <span class="fr-mr-1w fr-grid-row">
                                             {% include theme('svg/administration.svg') %}
@@ -91,7 +91,7 @@
                                 <li>
                                     <a
                                         href="{{ url_for('security.logout') }}"
-                                        class="fr-link fr-icon-logout-box-r-line"
+                                        class="fr-btn fr-icon-logout-box-r-line"
                                     >
                                         {{ _('Logout') }}
                                     </a>
@@ -100,7 +100,7 @@
                                 <li>
                                     <a
                                         href="{{ url_for('security.login', next=next_url) }}"
-                                        class="fr-link fr-icon-lock-line"
+                                        class="fr-btn fr-icon-lock-line"
                                     >
                                         {{ _('Log in') }}
                                     </a>
@@ -109,7 +109,7 @@
                                 <li>
                                     <a
                                         href="{{ url_for('security.register', next=next_url) }}"
-                                        class="fr-link fr-icon-account-line"
+                                        class="fr-btn fr-icon-account-line"
                                     >
                                         {{ _("Sign up") }}
                                     </a>

--- a/udata_front/theme/gouvfr/templates/macros/certified.html
+++ b/udata_front/theme/gouvfr/templates/macros/certified.html
@@ -1,6 +1,9 @@
 {% macro badge_if_certified(org) %}
 {% if org.public_service %}
-<span title="{{_('The identity of this public service is certified by %(certifier)s', certifier=config.SITE_AUTHOR)}}">
+<span
+    class="fr-icon-svg fr-icon--sm"
+    title="{{_('The identity of this public service is certified by %(certifier)s', certifier=config.SITE_AUTHOR)}}"
+>
     {% include theme('svg/certified.svg') %}
 </span>
 {% endif %}

--- a/udata_front/theme/gouvfr/templates/organization/producer-name-with-logo.html
+++ b/udata_front/theme/gouvfr/templates/organization/producer-name-with-logo.html
@@ -13,7 +13,7 @@
     </div>
     <p class="fr-col fr-m-0">
         {% if producer_type == 'organization' %}
-            <a href="{{ url_for('organizations.show', org=organization) }}">
+            <a class="fr-link" href="{{ url_for('organizations.show', org=organization) }}">
                 {{organization_name_with_certificate(organization)}}
             </a>
         {% else %}

--- a/udata_front/theme/gouvfr/templates/reuse/card.html
+++ b/udata_front/theme/gouvfr/templates/reuse/card.html
@@ -20,6 +20,7 @@
                     {{ _(' by ') }}
                     {% if reuse.organization %}
                     <a
+                        class="fr-link"
                         href="{{ url_for('organizations.show', org=reuse.organization) }}"
                     >
                         {{organization_name_with_certificate(reuse.organization)}}


### PR DESCRIPTION
Add back color to links outside of content.

Links in markdown are blue too for backward compatibility but should be black based on DSFR spec.

This left non-markdown links in content as black, because the default `a` color isn't forced as blue to reduce discrepancy between us and the DSFR.