### PR TITLE
Add version in js chunk file name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           command: |
             virtualenv venv
             source venv/bin/activate
-            pip install setuptools==66.1.1
+            pip install --force-reinstall setuptools==66.1.1
             pip install pip-tools
       - run:
           name: Upgrade udata to latest pypi release if tagged release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           command: |
             virtualenv venv
             source venv/bin/activate
-            pip install --force-reinstall setuptools==66.1.1
+            pip install setuptools==66.1.1
             pip install pip-tools
       - run:
           name: Upgrade udata to latest pypi release if tagged release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Update the login form after Flask-Security and WTForms upgrade [#224](https://github.com/etalab/udata-front/pull/224)
 - Align reuse sidebar with image [#234](https://github.com/etalab/udata-front/pull/234)
 - Show relative date on dataset and resource cards [#231](https://github.com/etalab/udata-front/pull/231)
+- Add version in chunk file names for cache invalidation [#239](https://github.com/etalab/udata-front/pull/239)
 
 ## 3.2.1 (2023-03-28)
 

--- a/bumpr.rc
+++ b/bumpr.rc
@@ -10,6 +10,7 @@ tests = inv test
 publish = inv dist
 files =
     README.md
+    package.json
 
 [bump]
 unsuffix = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "udata-front",
-  "version": "1.0.0",
+  "version": "3.2.2.dev",
   "description": "Open Data Portal - French customization",
   "author": "Etalab",
   "scripts": {

--- a/udata_front/theme/__init__.py
+++ b/udata_front/theme/__init__.py
@@ -30,8 +30,13 @@ current = LocalProxy(get_current_theme)
 
 
 @pass_context
-def theme_static_with_version(ctx, filename, external=False):
-    '''Override the default theme static to add cache burst'''
+def theme_static_with_version(ctx, filename, external=False, inline_burst=False):
+    '''
+    Override the default theme static to add cache burst, ex: [file].js?_=[burst]
+    If inline_burst is true, burst is not added as a dummy param but in filename directly:
+    Ex: [file].[burst].js
+    It is useful for generated chunks that follow this pattern
+    '''
     if current_app.theme_manager.static_folder:
         url = assets.cdn_for('_themes.static',
                              filename=current.identifier + '/' + filename,
@@ -47,6 +52,9 @@ def theme_static_with_version(ctx, filename, external=False):
         burst = time()
     else:
         burst = current.entrypoint.dist.version
+    if inline_burst:
+        url_parts = url.split(".")
+        return '.'.join(url_parts[:-1] + [str(burst), url_parts[-1]])
     return '{url}?_={burst}'.format(url=url, burst=burst)
 
 

--- a/udata_front/theme/gouvfr/templates/raw.html
+++ b/udata_front/theme/gouvfr/templates/raw.html
@@ -65,7 +65,7 @@
     <script nomodule src="{{ theme_static('js/s.min.js') }}"></script>
     <script nomodule src="{{ theme_static('js/vue.esm-browser.prod-legacy.js') }}"></script>
     <script nomodule src="{{ theme_static('js/vue-content-loader.es-legacy.js') }}"></script>
-    <script nomodule src="{{ theme_static('js/_commonjsHelpers-legacy.js') }}"></script>
+    <script nomodule src="{{ theme_static('js/_commonjsHelpers-legacy.js', inline_burst=True) }}"></script>
     <script nomodule src="{{ theme_static('js/polyfills-legacy.js') }}"></script>
     <script nomodule src="{{ theme_static('js/index-legacy.js') }}"></script>
     {% block extra_js %}{% endblock %}

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,12 @@ import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'url'
 import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
 
+
+function get_package_version(){
+  var pjson = require('./package.json');
+  return pjson.version
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
   base: "/_themes/gouvfr/",
@@ -49,7 +55,7 @@ export default defineConfig({
       output: {
         dir: "./udata_front/theme/gouvfr/static/",
         entryFileNames: `js/[name].js`,
-        chunkFileNames: `js/[name].[hash].js`,
+        chunkFileNames: `js/[name].${get_package_version()}.js`,
         assetFileNames: `assets/[name].[ext]`,
         // Provide global variables to use in the UMD build
         // for externalized deps

--- a/vite.config.js
+++ b/vite.config.js
@@ -49,7 +49,7 @@ export default defineConfig({
       output: {
         dir: "./udata_front/theme/gouvfr/static/",
         entryFileNames: `js/[name].js`,
-        chunkFileNames: `js/[name].js`,
+        chunkFileNames: `js/[name].[hash].js`,
         assetFileNames: `assets/[name].[ext]`,
         // Provide global variables to use in the UMD build
         // for externalized deps


### PR DESCRIPTION
Applies to _commonjsHelpers only in our case.

It allows us to version this file, preventing using a previous cached version that has changed.