### PR TITLE
Fix deps issue in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
             virtualenv venv
             source venv/bin/activate
             pip install --force-reinstall setuptools==66.1.1
-            pip install pip-tools
+            pip install --upgrade pip-tools
       - run:
           name: Upgrade udata to latest pypi release if tagged release
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,8 @@ jobs:
           command: export BASE_BRANCH=$(base_branch)
       - restore_cache:
           keys:
-          - py-cache-v16-{{ arch }}-master
+          - py-cache-v16-{{ arch }}-{{ .Branch }}
+          - py-cache-v16-{{ arch }}-{{ .Environment.BASE_BRANCH }}
       - run:
           name: Create venv and install pip-tools
           # FIXME: For now, we fix setuptools due to https://github.com/etalab/data.gouv.fr/issues/1041
@@ -29,7 +30,6 @@ jobs:
             virtualenv venv
             source venv/bin/activate
             pip install --force-reinstall setuptools==66.1.1
-            pip install pip-tools==6.12.3
             pip install --upgrade pip-tools
       - run:
           name: Upgrade udata to latest pypi release if tagged release
@@ -91,6 +91,10 @@ jobs:
                         -r requirements/test.pip \
                         -r requirements/develop.pip
             pip install -e .
+      - save_cache:
+          key: py-cache-v16-{{ arch }}-{{ .Branch }}
+          paths:
+          - venv
       - run:
           name: Run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,7 @@ jobs:
           command: export BASE_BRANCH=$(base_branch)
       - restore_cache:
           keys:
-          - py-cache-v16-{{ arch }}-{{ .Branch }}
-          - py-cache-v16-{{ arch }}-{{ .Environment.BASE_BRANCH }}
+          - py-cache-v17-{{ arch }}-master
       - run:
           name: Create venv and install pip-tools
           # FIXME: For now, we fix setuptools due to https://github.com/etalab/data.gouv.fr/issues/1041
@@ -91,10 +90,6 @@ jobs:
                         -r requirements/test.pip \
                         -r requirements/develop.pip
             pip install -e .
-      - save_cache:
-          key: py-cache-v16-{{ arch }}-{{ .Branch }}
-          paths:
-          - venv
       - run:
           name: Run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
             source venv/bin/activate
             pip install --force-reinstall setuptools==66.1.1
             pip install pip-tools==6.12.3
+            pip install --upgrade pip-tools
       - run:
           name: Upgrade udata to latest pypi release if tagged release
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           command: export BASE_BRANCH=$(base_branch)
       - restore_cache:
           keys:
-          - py-cache-v17-{{ arch }}-master
+          - py-cache-v16-{{ arch }}-master
       - run:
           name: Create venv and install pip-tools
           # FIXME: For now, we fix setuptools due to https://github.com/etalab/data.gouv.fr/issues/1041

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
             virtualenv venv
             source venv/bin/activate
             pip install --force-reinstall setuptools==66.1.1
-            pip install --upgrade pip-tools
+            pip install pip-tools==6.12.3
       - run:
           name: Upgrade udata to latest pypi release if tagged release
           command: |

--- a/README.md
+++ b/README.md
@@ -253,7 +253,6 @@ npm run test
 
 Cypress also comes with [cypress-axe](https://github.com/component-driven/cypress-axe) to allow for accessibility automated testing.
 
-## 📖 Read more
 
 [udata]: https://github.com/opendatateam/udata
 [udata-doc]: http://udata.readthedocs.io/en/stable/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     <img src="https://user-images.githubusercontent.com/60264344/134811326-27109632-f653-4025-9786-482824635994.png">
 </p>
 <p align="center">
-    <i>⚙️ Udata customizations for data.gouv.fr made by Etalab ⚙️</i>
+    <i>Udata customizations for data.gouv.fr made by Etalab</i>
     <br>
     <br>
     <img src="https://img.shields.io/github/contributors/etalab/udata-front">


### PR DESCRIPTION
Investigating on [erroneous master CI build](https://app.circleci.com/pipelines/github/etalab/udata-front/2163/workflows/783f5851-c4be-48c7-a7b8-183ea3591bf5/jobs/9927).
It seems to be linked with pip / pip-tools versions used. In particular, we need to use compatible versions following changes made to WheelCache in both. pip-tools adds support for pip 23.1 with this [corresponding commit](https://github.com/jazzband/pip-tools/commit/33128f515392a950b8cc45c8d3f51ff615499c5f).
We thus make sure to upgrade pip-tools, even if already installed to use latest 6.13.0 version.

On a new cache, I don't reproduce the issue and I've tried using the master cache, without success. I've manually installed the corresponding cached pip-tools version to reproduce the issue in https://github.com/etalab/udata-front/pull/240/commits/10f742431aebe7a9295b9277aef6604fc8dc2834.
Adding `--upgrade` in https://github.com/etalab/udata-front/pull/240/commits/e4783ffafae74ba6f4b0719f670f5752edda3dc8 does seem to fix the issue.