### PR TITLE
Fix `.fr-btn` in markdown content (pages)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Handle previous format of link to discussions, e.g. from e-mails [#241](https://github.com/etalab/udata-front/pull/241)
+- Fix `.fr-btn` in `.markdown` [#243](https://github.com/etalab/udata-front/pull/243)
 
 ## 3.2.2 (2023-04-18)
 

--- a/theme/less/components/markdown.less
+++ b/theme/less/components/markdown.less
@@ -108,7 +108,7 @@ Content on the site can be styled with Markdown. Ready made styles are provided 
         max-width: 100%;
     }
 
-    a {
+    a:not(.fr-btn) {
         .fr-link;
     }
 


### PR DESCRIPTION
`a` in markdown have `.fr-link` style applied to them to match previous udata design instead of the DSFR black default.

This introduced some unexpected side-effects for links styled with `.fr-btn` in pages.

Example : https://www.data.gouv.fr/fr/pages/onboarding/prise_appel_secours/