### PR TITLE
Fix vueFiles glob pattern for i18n extract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 > This renames the `theme` root folder to `assets` and moves it inside gouvfr theme.
 > This also updates most references of `udata_front/theme/gouvfr` theme to `*` to ease the usage of other themes.
 
-- Move `theme` to `udata_front/theme/gouvfr`[#244](https://github.com/etalab/udata-front/pull/244)
+- Move `theme` to `udata_front/theme/gouvfr`[#244](https://github.com/etalab/udata-front/pull/244) [#252](https://github.com/etalab/udata-front/pull/252)
 - MonComptePro SSO integration [#237](https://github.com/etalab/udata-front/pull/237):
     - New button on login and register page
     - When loging in, the datastore will seek for a coresponding user on udata. If such user does not exist, she will be created.

--- a/vue-i18n-extract.config.js
+++ b/vue-i18n-extract.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  "vueFiles": "?(udata_front|udata-front-plugins-helper)/**/?(js|src)/**/*.?(js|vue)",
+  "vueFiles": "{udata_front,udata-front-plugins-helper}/**/{assets/js,src}/**/*.{js,vue}",
   "languageFiles": "udata_front/theme/**/js/locales/**/*.?(json|yaml|yml|js)",
   "exclude": [],
   "output": false,


### PR DESCRIPTION
With the previous glob pattern, many strings were extracted from static files instead of source files.