### PR TITLE
Remove cache around dataset, reuse and organization modify button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Current (in progress)
 
 - Fix `img` folder not copied [#255](https://github.com/etalab/udata-front/pull/255)
-- Remove cache around on dataset, reuse and organization modify button [#256](https://github.com/etalab/udata-front/pull/256)
+- Remove cache around dataset, reuse and organization modify button [#256](https://github.com/etalab/udata-front/pull/256)
 
 ## 3.2.3 (2023-05-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Fix `img` folder not copied [#255](https://github.com/etalab/udata-front/pull/255)
+- Remove cache around on dataset, reuse and organization modify button [#256](https://github.com/etalab/udata-front/pull/256)
 
 ## 3.2.3 (2023-05-16)
 

--- a/udata_front/theme/gouvfr/templates/dataset/display.html
+++ b/udata_front/theme/gouvfr/templates/dataset/display.html
@@ -47,7 +47,6 @@
 {% endblock %}
 
 {% block toolbar %}
-{% cache cache_duration, 'dataset-toolbar', dataset.id|string, g.lang_code, dataset.last_modified|string %}
 {{ follow_btn(dataset) }}
 {{ hook('dataset.display.explore-button') }}
 {% if can_edit %}
@@ -60,7 +59,6 @@
         </a>
     </div>
 {% endif %}
-{% endcache %}
 {% endblock %}
 
 {% block content %}

--- a/udata_front/theme/gouvfr/templates/organization/display.html
+++ b/udata_front/theme/gouvfr/templates/organization/display.html
@@ -44,7 +44,6 @@
 {% endblock %}
 
 {% block toolbar %}
-{% cache cache_duration, 'org-toolbar', org.id|string, g.lang_code, org.last_modified|string %}
 {{ follow_btn(org) }}
 {% if can_edit %}
     <a
@@ -54,7 +53,6 @@
         {{ _('Modify organization') }}
     </a>
 {% endif %}
-{% endcache %}
 {% endblock %}
 
 {% block main_content %}

--- a/udata_front/theme/gouvfr/templates/reuse/display.html
+++ b/udata_front/theme/gouvfr/templates/reuse/display.html
@@ -45,7 +45,6 @@
 {% endblock %}
 
 {% block toolbar %}
-{% cache cache_duration, 'reuse-toolbar', reuse.id|string, g.lang_code, reuse.last_modified|string %}
 {{ follow_btn(reuse) }}
 <a
     href="{{ reuse.url }}"
@@ -64,7 +63,6 @@
         </a>
     </div>
 {% endif %}
-{% endcache %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
With the current cache, if an user who can edit opens the page, the button is cached and any following user will see the button to edit.

@nicolaskempf57 do you think we should keep a cache mechanic for follow, explore or open reuse buttons on the toolbar still?
I've removed the cache on the entire block, but it may still be valuable on the other toolbar buttons?