### PR TITLE
Fix header search

### DIFF
--- a/udata_front/theme/gouvfr/assets/less/content/visibility.less
+++ b/udata_front/theme/gouvfr/assets/less/content/visibility.less
@@ -82,3 +82,7 @@ each(@dsfr-breakpoints, .(@bk, @_k, @_i) {
 .z-2 {
     z-index: 2 !important;
 }
+
+.overflow-visible {
+    overflow: visible;
+}

--- a/udata_front/theme/gouvfr/templates/header.html
+++ b/udata_front/theme/gouvfr/templates/header.html
@@ -119,7 +119,7 @@
                         </ul>
                     </div>
                     <div class="fr-header__search fr-modal" id="modal-search">
-                        <div class="fr-container fr-container-lg--fluid relative">
+                        <div class="fr-container fr-container-lg--fluid relative overflow-visible">
                             <button class="fr-btn--close fr-btn" aria-controls="modal-search">{{ _('Close') }}</button>
                             <form action="/datasets">
                                 <div class="fr-search-bar vuejs" id="search" role="search" aria-label="{{  _('Search for data') }}">


### PR DESCRIPTION
DSFR adds a `overflow: hidden` to `fr-container-lg--fluid` so it hides our popup from showing.