### PR TITLE
Redirect *pages* when missing trailing slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix dataset oembed links [#271](https://github.com/etalab/udata-front/pull/271)
 - Hide CaptchEtat icon loader [#272](https://github.com/etalab/udata-front/pull/272)
 - Update guide links [#276](https://github.com/etalab/udata-front/pull/276)
+- Redirect *pages* when missing trailing slash [#278](https://github.com/etalab/udata-front/pull/278)
 
 ## 3.2.4 (2023-06-19)
 

--- a/udata_front/tests/test_static_pages.py
+++ b/udata_front/tests/test_static_pages.py
@@ -19,21 +19,21 @@ class StaticPagesTest:
         raw_url, gh_url = get_pages_gh_urls('doesnotexist')
         rmock.head(f'{raw_url}.md', status_code=404)
         rmock.get(f'{raw_url}.html', status_code=404)
-        response = client.get(url_for('gouvfr.show_page', slug='doesnotexist'))
+        response = client.get(url_for('gouvfr.show_page', slug='doesnotexist/'))
         assert response.status_code == 404
 
     def test_page_error_no_cache(self, client, rmock):
         raw_url, gh_url = get_pages_gh_urls('doesnotexist')
         rmock.head(f'{raw_url}.md', status_code=500)
         rmock.get(f'{raw_url}.html', status_code=500)
-        response = client.get(url_for('gouvfr.show_page', slug='doesnotexist'))
+        response = client.get(url_for('gouvfr.show_page', slug='doesnotexist/'))
         assert response.status_code == 503
 
     def test_page_timeout_no_cache(self, client, rmock):
         raw_url, gh_url = get_pages_gh_urls('doesnotexist')
         rmock.head(f'{raw_url}.md', status_code=404)
         rmock.get(f'{raw_url}.html', exc=requests.exceptions.ConnectTimeout)
-        response = client.get(url_for('gouvfr.show_page', slug='doesnotexist'))
+        response = client.get(url_for('gouvfr.show_page', slug='doesnotexist/'))
         assert response.status_code == 503
 
     def test_page_error_w_cache(self, client, rmock, mocker):
@@ -43,11 +43,11 @@ class StaticPagesTest:
         # fill cache
         rmock.head(f'{raw_url}.md', status_code=200)
         rmock.get(f'{raw_url}.md', text="""#test""")
-        response = client.get(url_for('gouvfr.show_page', slug='cache1'))
+        response = client.get(url_for('gouvfr.show_page', slug='cache1/'))
         assert cache_mock_set.called
         rmock.head(f'{raw_url}.md', status_code=500)
         rmock.get(f'{raw_url}.html', status_code=500)
-        response = client.get(url_for('gouvfr.show_page', slug='cache1'))
+        response = client.get(url_for('gouvfr.show_page', slug='cache1/'))
         assert response.status_code == 200
         assert b'dummy_from_cache' in response.data
         assert rmock.call_count == 4
@@ -57,7 +57,7 @@ class StaticPagesTest:
         raw_url, _ = get_pages_gh_urls('cache1')
         rmock.head(f'{raw_url}.md', status_code=500)
         rmock.get(f'{raw_url}.html', status_code=500)
-        response = client.get(url_for('gouvfr.show_page', slug='cache1'))
+        response = client.get(url_for('gouvfr.show_page', slug='cache1/'))
         assert response.status_code == 503
 
     def test_page_extension_detection_md(self, client, rmock):
@@ -76,7 +76,7 @@ class StaticPagesTest:
         raw_url, _ = get_pages_gh_urls('test')
         rmock.head(f'{raw_url}.md', status_code=200)
         rmock.get(f'{raw_url}.md', text="""#test""")
-        response = client.get(url_for('gouvfr.show_page', slug='test'))
+        response = client.get(url_for('gouvfr.show_page', slug='test/'))
         assert response.status_code == 200
         assert b'<h1>test</h1>' in response.data
 
@@ -84,7 +84,7 @@ class StaticPagesTest:
         raw_url, _ = get_pages_gh_urls('test')
         rmock.head(f'{raw_url}.md', status_code=404)
         rmock.get(f'{raw_url}.html', text="""<h1>test</h1>""")
-        response = client.get(url_for('gouvfr.show_page', slug='test'))
+        response = client.get(url_for('gouvfr.show_page', slug='test/'))
         assert response.status_code == 200
         assert b'<h1>test</h1>' in response.data
 
@@ -97,7 +97,7 @@ reuses:
 ---
 #test
 """)
-        response = client.get(url_for('gouvfr.show_page', slug='test'))
+        response = client.get(url_for('gouvfr.show_page', slug='test/'))
         assert response.status_code == 200
 
     def test_page_inject_objects(self, client, rmock):
@@ -113,7 +113,7 @@ reuses:
 ---
 #test
 """)
-        response = client.get(url_for('gouvfr.show_page', slug='test'))
+        response = client.get(url_for('gouvfr.show_page', slug='test/'))
         assert response.status_code == 200
         assert str(dataset.title).encode('utf-8') in response.data
         assert str(url_for('reuses.show', reuse=reuse)).encode('utf-8') in response.data
@@ -122,7 +122,7 @@ reuses:
         raw_url, _ = get_pages_gh_urls('subdir/test')
         rmock.head(f'{raw_url}.md', status_code=200)
         rmock.get(f'{raw_url}.md', text="""#test""")
-        response = client.get(url_for('gouvfr.show_page', slug='subdir/test'))
+        response = client.get(url_for('gouvfr.show_page', slug='subdir/test/'))
         assert response.status_code == 200
         assert b'<h1>test</h1>' in response.data
 

--- a/udata_front/tests/test_static_pages.py
+++ b/udata_front/tests/test_static_pages.py
@@ -125,3 +125,12 @@ reuses:
         response = client.get(url_for('gouvfr.show_page', slug='subdir/test'))
         assert response.status_code == 200
         assert b'<h1>test</h1>' in response.data
+
+    def test_page_missing_trailing_slash(self, client, rmock):
+        raw_url, _ = get_pages_gh_urls('subdir/test')
+        rmock.head(f'{raw_url}.md', status_code=200)
+        rmock.get(f'{raw_url}.md', text="""#test""")
+        url_missing_trailing_slash = url_for('gouvfr.show_page', slug='subdir/test').rstrip('/')
+        response = client.get(url_missing_trailing_slash)
+        assert response.status_code == 302
+        assert response.location == url_missing_trailing_slash + '/'

--- a/udata_front/views/gouvfr.py
+++ b/udata_front/views/gouvfr.py
@@ -110,9 +110,12 @@ def get_object(model, id_or_slug):
     return obj
 
 
-@blueprint.route('/pages/<path:slug>/')
+@blueprint.route('/pages/<path:slug>', endpoint='show_page')
 def show_page(slug):
-    content, gh_url, extension = get_page_content(slug)
+    # We expect a trailing slash in route and redirect if missing
+    if not slug.endswith('/'):
+        return redirect(url_for('gouvfr.show_page', slug=slug + '/'))
+    content, gh_url, extension = get_page_content(slug.rstrip('/'))
     page = frontmatter.loads(content)
     reuses = [get_object(Reuse, r) for r in page.get('reuses') or []]
     datasets = [get_object(Dataset, d) for d in page.get('datasets') or []]


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/1097

Having a trailing slash in `@blueprint.route('/pages/<path:slug>/')` did not apply redirect when missing trailing slash, due to `path:` [Variable Rule](https://flask.palletsprojects.com/en/2.1.x/quickstart/#variable-rules).

Removed the explicit trailing slash in the route but added an explicit redirect if missing. We try to mimic the trailing slash behavior applied by flask in other cases (described in https://flask.palletsprojects.com/en/2.1.x/quickstart/#unique-urls-redirection-behavior).

There may be a better way to have the trailing slash redirect behavior with `:path` Variable Rule, without having to code it explicitly, but I haven't found find it yet.
