### PR TITLE
Set confirmed_at when creating user in MonComptePro auth

### DIFF
--- a/udata_front/views/mcp.py
+++ b/udata_front/views/mcp.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from flask import abort, url_for, redirect
 from udata.i18n import I18nBlueprint
 from udata_front.frontend import oauth
@@ -34,6 +36,7 @@ def auth():
             email=mcp_user['email'],
             first_name=mcp_user.get('given_name'),
             last_name=mcp_user.get('family_name'),
+            confirmed_at=datetime.now()
             )
 
     if not login_user(user):


### PR DESCRIPTION
When creating a user in MCP auth, we should set `confirmed_at`, since:
* this field is missing when trying to call `/reset`
* email confirmation is MCP responsibility anyway

I think we're missing tests right now?