### PR TITLE
Update read-more height on detail toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Update certified icon [#288](https://github.com/etalab/udata-front/pull/288)
 - Add guides to the menu [#290](https://github.com/etalab/udata-front/pull/290)
 - Add resource permalink [#286](https://github.com/etalab/udata-front/pull/286)
+- Update read-more height on `details` toggle [#294](https://github.com/etalab/udata-front/pull/294)
 
 ## 3.2.5 (2023-07-19)
 

--- a/udata_front/theme/gouvfr/assets/js/components/utils/read-more.vue
+++ b/udata_front/theme/gouvfr/assets/js/components/utils/read-more.vue
@@ -110,6 +110,9 @@ export default defineComponent({
     onMounted(() => {
       updateReadMoreHeight();
       setTimeout(() => updateReadMoreHeight(), 500);
+      document.querySelectorAll(".read-more details").forEach(
+        (detail) => { detail.addEventListener("toggle", updateReadMoreHeight); }
+      )
     });
 
     return {

--- a/udata_front/theme/gouvfr/assets/js/components/utils/read-more.vue
+++ b/udata_front/theme/gouvfr/assets/js/components/utils/read-more.vue
@@ -110,7 +110,7 @@ export default defineComponent({
     onMounted(() => {
       updateReadMoreHeight();
       setTimeout(() => updateReadMoreHeight(), 500);
-      document.querySelectorAll(".read-more details").forEach(
+      container.value?.querySelectorAll("details").forEach(
         (detail) => { detail.addEventListener("toggle", updateReadMoreHeight); }
       )
     });


### PR DESCRIPTION
Related to https://github.com/etalab/data.gouv.fr/issues/1140.

Useful when adding `<details>` in description since https://github.com/opendatateam/udata/pull/2879