### PR TITLE
Moving reuse metrics hook before discussion section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Update build dependencies [#309](https://github.com/etalab/udata-front/pull/309)
 - Add read-more to discussions [#310](https://github.com/etalab/udata-front/pull/310)
+- Add metric components and hooks [#260](https://github.com/etalab/udata-front/pull/260) [#313](https://github.com/etalab/udata-front/pull/313)
 
 ## 3.2.8 (2023-10-26)
 

--- a/udata_front/theme/gouvfr/templates/reuse/display.html
+++ b/udata_front/theme/gouvfr/templates/reuse/display.html
@@ -174,6 +174,9 @@
         {% include theme('dataset/search-results.html') %}
         {% endwith %}
     </section>
+
+    {{ hook('reuse.display.metrics') }}
+
     <section class="community_container fr-py-5v border-bottom" id="community">
         <div class="vuejs">
             {% if not reuse.metrics.discussions %}
@@ -219,8 +222,6 @@
             </div>
         {% endif %}
     </section>
-
-    {{ hook('reuse.display.metrics') }}
 
 </div>
 {% endcache %}


### PR DESCRIPTION
New layout on DVF reuse page:
![image](https://github.com/etalab/udata-front/assets/28541902/327e4159-41c0-40ec-ab69-f9fdeda318f1)
