### PR TITLE
Add 1.5 padding to charts layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Update build dependencies [#309](https://github.com/etalab/udata-front/pull/309)
 - Add read-more to discussions [#310](https://github.com/etalab/udata-front/pull/310)
-- Add metric components and hooks [#260](https://github.com/etalab/udata-front/pull/260) [#313](https://github.com/etalab/udata-front/pull/313)
+- Add metric components and hooks [#260](https://github.com/etalab/udata-front/pull/260) [#313](https://github.com/etalab/udata-front/pull/313) [#314](https://github.com/etalab/udata-front/pull/314)
 
 ## 3.2.8 (2023-10-26)
 

--- a/udata_front/theme/gouvfr/assets/js/components/charts/chart.vue
+++ b/udata_front/theme/gouvfr/assets/js/components/charts/chart.vue
@@ -108,6 +108,11 @@ export default defineComponent({
               }
             },
           },
+          layout: {
+            padding: {
+                top: 1.5 // half border width
+            }
+          },
         },
       });
     });


### PR DESCRIPTION
We want to make sure lines don't get cut off.

There seem to be long time conversation on this topic with no satisfying solution : https://github.com/chartjs/Chart.js/issues/4202.

I've followed one of the [approach proposed in this comment](https://github.com/chartjs/Chart.js/issues/4202#issuecomment-432063858).
`clip: false` alternative did not seem to work in our case.