### PR TITLE
Hide quality score for specific harvest backends

### DIFF
--- a/udata_front/settings.py
+++ b/udata_front/settings.py
@@ -77,3 +77,6 @@ NEWSLETTER_SUBSCRIPTION_URL = 'https://f.info.data.gouv.fr/f/lp/infolettre-data-
 
 # Metrics API
 METRICS_API = None
+
+# Metadata quality is hidden for datasets harvested from theses backends
+QUALITY_METADATA_BACKEND_IGNORE = []

--- a/udata_front/settings.py
+++ b/udata_front/settings.py
@@ -78,5 +78,5 @@ NEWSLETTER_SUBSCRIPTION_URL = 'https://f.info.data.gouv.fr/f/lp/infolettre-data-
 # Metrics API
 METRICS_API = None
 
-# Metadata quality is hidden for datasets harvested from theses backends
+# Metadata quality is hidden for datasets harvested from these backends
 QUALITY_METADATA_BACKEND_IGNORE = []

--- a/udata_front/theme/gouvfr/assets/js/components/dataset/card-lg.vue
+++ b/udata_front/theme/gouvfr/assets/js/components/dataset/card-lg.vue
@@ -55,7 +55,9 @@
         <p class="fr-mt-1w fr-mb-2w fr-hidden fr-unhidden-sm overflow-wrap-anywhere">
           {{ excerpt(dataset.description, 160) }}
         </p>
-        <div class="fr-m-0 fr-grid-row fr-grid-row--middle fr-text--sm text-mention-grey">
+        <div
+          v-if="!(dataset.harvest && quality_metadata_backend_ignore.includes(dataset.harvest.backend))"
+          class="fr-m-0 fr-grid-row fr-grid-row--middle fr-text--sm text-mention-grey">
           <div class="fr-grid-row fr-grid-row--middle fr-hidden flex-sm dash-after text-grey-500 not-enlarged">
             <Toggletip
               class="fr-btn fr-btn--tertiary-no-outline fr-btn--secondary-grey-500 fr-icon-info-line"
@@ -169,7 +171,7 @@ import QualityScore from "./quality-score.vue";
 import Toggletip from "../utils/Toggletip/Toggletip.vue";
 import QualityItem from "./quality-item.vue";
 import { excerpt } from "../../helpers";
-import { guides_quality_url } from "../../config";
+import { guides_quality_url, quality_metadata_backend_ignore } from "../../config";
 import type { Dataset } from "../../types";
 
 export default defineComponent({
@@ -205,6 +207,7 @@ export default defineComponent({
       excerpt,
       formatRelativeIfRecentDate,
       guides_quality_url,
+      quality_metadata_backend_ignore,
       license,
       id,
       ownerName,

--- a/udata_front/theme/gouvfr/assets/js/components/dataset/card-lg.vue
+++ b/udata_front/theme/gouvfr/assets/js/components/dataset/card-lg.vue
@@ -56,7 +56,7 @@
           {{ excerpt(dataset.description, 160) }}
         </p>
         <div
-          v-if="!(dataset.harvest && quality_metadata_backend_ignore.includes(dataset.harvest.backend))"
+          v-if="show_quality_score"
           class="fr-m-0 fr-grid-row fr-grid-row--middle fr-text--sm text-mention-grey">
           <div class="fr-grid-row fr-grid-row--middle fr-hidden flex-sm dash-after text-grey-500 not-enlarged">
             <Toggletip
@@ -203,11 +203,12 @@ export default defineComponent({
     const { id } = useUid("metadata-quality");
     const ownerName = useOwnerName(props.dataset);
     const license = useLicense(props.dataset.license);
+    const show_quality_score = !(props.dataset.harvest && quality_metadata_backend_ignore.includes(props.dataset.harvest.backend));
     return {
       excerpt,
       formatRelativeIfRecentDate,
       guides_quality_url,
-      quality_metadata_backend_ignore,
+      show_quality_score,
       license,
       id,
       ownerName,

--- a/udata_front/theme/gouvfr/assets/js/config.ts
+++ b/udata_front/theme/gouvfr/assets/js/config.ts
@@ -280,6 +280,8 @@ export const search_autocomplete_debounce = _jsonMeta("search-autocomplete-debou
 
 export const explorable_resources: Array<string> = _jsonMeta("explorable-resources") || [];
 
+export const quality_metadata_backend_ignore: Array<string> = _jsonMeta("quality-metadata-backend-ignore") || [];
+
 export default {
   user,
   debug,
@@ -318,4 +320,5 @@ export default {
   markdown,
   read_only_enabled,
   quality_description_length,
+  quality_metadata_backend_ignore,
 };

--- a/udata_front/theme/gouvfr/assets/js/types.ts
+++ b/udata_front/theme/gouvfr/assets/js/types.ts
@@ -93,6 +93,10 @@ export type Quality = {
   update_fulfilled_in_time: boolean;
 }
 
+export type Harvest = {
+  backend: string;
+}
+
 export type NewDataset = Owned & {
 title: string;
 acronym: string;
@@ -124,6 +128,7 @@ uri: string;
 slug: string;
 quality: Quality;
 metrics: { discussions: number; followers: number; reuses: number; views: number; };
+harvest: Harvest;
 };
 
 export type Reuse = Owned & {

--- a/udata_front/theme/gouvfr/templates/dataset/card-lg.html
+++ b/udata_front/theme/gouvfr/templates/dataset/card-lg.html
@@ -1,6 +1,9 @@
 {% cache cache_duration, 'dataset-card-lg', dataset.id|string, g.lang_code %}
 {% from theme('macros/organization_name_with_certificate.html') import organization_name_with_certificate %}
 {% from theme('macros/quality_score_inline.html') import quality_score_inline %}
+
+{% set show_quality_score = not(dataset.harvest and dataset.harvest.backend in config.QUALITY_METADATA_BACKEND_IGNORE) %}
+
 <article class="fr-my-3w fr-p-3w border border-default-grey fr-enlarge-link" style="z-index: {{loop.length - loop.index0 + 1}}">
     {% if dataset.private or dataset.archived %}
     <div class="absolute top-0 fr-grid-row fr-grid-row--middle fr-mt-n3v">
@@ -77,7 +80,9 @@
                 {{ dataset.description|mdstrip(300) }}
             </p>
             <div class="fr-mb-0 text-mention-grey fr-grid-row fr-grid-row--middle">
-                {{quality_score_inline(dataset, "fr-hidden fr-unhidden-sm dash-after text-grey-500")}}
+                {% if show_quality_score %}
+                    {{quality_score_inline(dataset, "fr-hidden fr-unhidden-sm dash-after text-grey-500")}}
+                {% endif %}
                 <p class="fr-m-0">
                     {{ _('Updated %(date)s', date=dataset.last_update|format_based_on_date) }}
                 </p>

--- a/udata_front/theme/gouvfr/templates/macros/metadata.html
+++ b/udata_front/theme/gouvfr/templates/macros/metadata.html
@@ -100,6 +100,8 @@
 }|tojson|urlencode }}" />
 <meta name="read-only-enabled" content="{{ 'true' if config.READ_ONLY_MODE else 'false' }}">
 
+<meta name="quality-metadata-backend-ignore" content="{{ config.QUALITY_METADATA_BACKEND_IGNORE|tojson|urlencode }}" />
+
 {% if json_ld %}
 <script id="json_ld" type="application/ld+json">{{ json_ld|embedded_json_ld }}</script>
 {% endif %}

--- a/udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html
+++ b/udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html
@@ -17,7 +17,7 @@
     {% if not show_quality_score %}
     <div class="text-mention-grey fr-text--sm fr-my-1v">
         <span class="fr-icon-warning-line fr-icon--sm" aria-hidden="true"></span>
-        {{_('Metadata quality may be misleading since metadata info may have been lost from original source')}}
+        {{_("Metadata quality may be misleading since metadata info may have been lost from original source. We're currently working on improving this.")}}
     </div>
     {% else %}
     {{quality_item_warning(

--- a/udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html
+++ b/udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html
@@ -3,6 +3,7 @@
 {% from theme('macros/quality_score.html') import quality_score %}
 
 {% macro quality_score_with_warning_below(dataset, class) %}
+{% set show_quality_score = not(dataset.harvest and dataset.harvest.backend in config.QUALITY_METADATA_BACKEND_IGNORE) %}
 <section aria-labelledby="metadata-quality">
     <div class="fr-grid-row fr-grid-row--middle fr-ml-n1v">
         {% call quality_score_toggletip(dataset, "fr-btn fr-btn--tertiary-no-outline fr-btn--secondary-grey-500 fr-icon-info-line") %}
@@ -13,7 +14,7 @@
         </h2>
     </div>
     {{quality_score(dataset.quality.score, "w-100")}}
-    {% if dataset.harvest and dataset.harvest.backend in config.QUALITY_METADATA_BACKEND_IGNORE %}
+    {% if not show_quality_score %}
     <div class="text-mention-grey fr-text--sm fr-my-1v">
         <span class="fr-icon-warning-line fr-icon--sm" aria-hidden="true"></span>
         {{_('Metadata quality may be misleading since metadata info may have been lost from original source')}}

--- a/udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html
+++ b/udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html
@@ -13,6 +13,12 @@
         </h2>
     </div>
     {{quality_score(dataset.quality.score, "w-100")}}
+    {% if dataset.harvest and dataset.harvest.backend in config.QUALITY_METADATA_BACKEND_IGNORE %}
+    <div class="text-mention-grey fr-text--sm fr-my-1v">
+        <span class="fr-icon-warning-line fr-icon--sm" aria-hidden="true"></span>
+        {{_('Metadata quality may be misleading since metadata info may have been lost from original source')}}
+    </div>
+    {% else %}
     {{quality_item_warning(
         dataset.quality.dataset_description_quality,
         _("Data description empty"),
@@ -53,5 +59,6 @@
         _("Some files are unavailable"),
         "fr-my-1v"
     )}}
+    {% endif %}
 </section>
 {% endmacro %}

--- a/udata_front/theme/gouvfr/translations/gouvfr.pot
+++ b/udata_front/theme/gouvfr/translations/gouvfr.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: udata-front 3.5.3.dev0\n"
 "Report-Msgid-Bugs-To: data.gouv@data.gouv.fr\n"
-"POT-Creation-Date: 2024-02-20 11:57+0100\n"
-"PO-Revision-Date: 2024-02-20 11:57+0100\n"
+"POT-Creation-Date: 2024-02-21 19:01+0100\n"
+"PO-Revision-Date: 2024-02-21 19:01+0100\n"
 "Last-Translator: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
 "Language: en\n"
 "Language-Team: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
@@ -680,7 +680,7 @@ msgstr ""
 msgid "Due to security reasons, the creation of new content is currently disabled."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/card-lg.html:10
+#: udata_front/theme/gouvfr/templates/dataset/card-lg.html:13
 #: udata_front/theme/gouvfr/templates/dataset/card-sm.html:9
 #: udata_front/theme/gouvfr/templates/dataset/card-xs.html:10
 #: udata_front/theme/gouvfr/templates/dataset/display.html:76
@@ -689,26 +689,26 @@ msgstr ""
 msgid "Private"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/card-lg.html:16
+#: udata_front/theme/gouvfr/templates/dataset/card-lg.html:19
 #: udata_front/theme/gouvfr/templates/dataset/card-sm.html:15
 #: udata_front/theme/gouvfr/templates/dataset/card-xs.html:16
 #: udata_front/theme/gouvfr/templates/dataset/display.html:93
 msgid "Archived"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/card-lg.html:60
+#: udata_front/theme/gouvfr/templates/dataset/card-lg.html:63
 #: udata_front/theme/gouvfr/templates/dataset/card-sm.html:59
 #: udata_front/theme/gouvfr/templates/dataset/card-xs.html:60
 msgid "From"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/card-lg.html:82
+#: udata_front/theme/gouvfr/templates/dataset/card-lg.html:87
 #: udata_front/theme/gouvfr/templates/dataset/card-sm.html:77
 #, python-format
 msgid "Updated %(date)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/card-lg.html:98
+#: udata_front/theme/gouvfr/templates/dataset/card-lg.html:103
 #: udata_front/theme/gouvfr/templates/organization/card.html:30
 #, python-format
 msgid "<strong class=\"fr-mr-1v\">%(num)d</strong> reuse"
@@ -716,7 +716,7 @@ msgid_plural "<strong class=\"fr-mr-1v\">%(num)d</strong> reuses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/dataset/card-lg.html:103
+#: udata_front/theme/gouvfr/templates/dataset/card-lg.html:108
 #, python-format
 msgid "<strong class=\"fr-mr-1v\">%(num)d</strong> favorite"
 msgid_plural "<strong class=\"fr-mr-1v\">%(num)d</strong> favorites"
@@ -1234,7 +1234,7 @@ msgid "Data description filled"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/quality_score_toggletip.html:14
-#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:24
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:25
 msgid "Data description empty"
 msgstr ""
 
@@ -1243,7 +1243,7 @@ msgid "Files documented"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/quality_score_toggletip.html:20
-#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:29
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:30
 msgid "Files documentation missing"
 msgstr ""
 
@@ -1252,7 +1252,7 @@ msgid "License filled"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/quality_score_toggletip.html:26
-#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:34
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:35
 msgid "No license set"
 msgstr ""
 
@@ -1261,12 +1261,12 @@ msgid "Update frequency followed"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/quality_score_toggletip.html:32
-#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:39
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:40
 msgid "Update frequency not followed"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/quality_score_toggletip.html:32
-#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:39
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:40
 msgid "Update frequency not set"
 msgstr ""
 
@@ -1275,7 +1275,7 @@ msgid "File formats are open"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/quality_score_toggletip.html:38
-#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:44
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:45
 msgid "File formats are closed"
 msgstr ""
 
@@ -1284,7 +1284,7 @@ msgid "Temporal coverage filled"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/quality_score_toggletip.html:44
-#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:49
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:50
 msgid "Temporal coverage not set"
 msgstr ""
 
@@ -1293,7 +1293,7 @@ msgid "Spatial coverage filled"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/quality_score_toggletip.html:50
-#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:54
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:55
 msgid "Spatial coverage not set"
 msgstr ""
 
@@ -1302,7 +1302,7 @@ msgid "All files are available"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/quality_score_toggletip.html:56
-#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:59
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:60
 msgid "Some files are unavailable"
 msgstr ""
 
@@ -1314,15 +1314,15 @@ msgstr ""
 msgid "Learn more about this indicator"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:9
-#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:12
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:10
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:13
 msgid "Metadata quality"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:19
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:20
 msgid ""
 "Metadata quality may be misleading since metadata info may have been lost "
-"from original source"
+"from original source. We're currently working on improving this."
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/search.html:17

--- a/udata_front/theme/gouvfr/translations/gouvfr.pot
+++ b/udata_front/theme/gouvfr/translations/gouvfr.pot
@@ -6,10 +6,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: udata-front 3.5.2.dev0\n"
+"Project-Id-Version: udata-front 3.5.3.dev0\n"
 "Report-Msgid-Bugs-To: data.gouv@data.gouv.fr\n"
-"POT-Creation-Date: 2024-02-15 12:09+0100\n"
-"PO-Revision-Date: 2024-02-15 12:09+0100\n"
+"POT-Creation-Date: 2024-02-20 11:57+0100\n"
+"PO-Revision-Date: 2024-02-20 11:57+0100\n"
 "Last-Translator: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
 "Language: en\n"
 "Language-Team: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
@@ -96,8 +96,8 @@ msgid "Data"
 msgstr ""
 
 #: udata_front/theme/gouvfr/__init__.py:47
-#: udata_front/theme/gouvfr/templates/dataset/display.html:215
-#: udata_front/theme/gouvfr/templates/dataset/display.html:280
+#: udata_front/theme/gouvfr/templates/dataset/display.html:216
+#: udata_front/theme/gouvfr/templates/dataset/display.html:281
 #: udata_front/theme/gouvfr/templates/home.html:84
 #: udata_front/theme/gouvfr/templates/organization/display.html:26
 #: udata_front/theme/gouvfr/templates/organization/display.html:128
@@ -234,7 +234,7 @@ msgstr[1] ""
 msgid "Download from "
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:116
+#: udata_front/theme/gouvfr/templates/dataset/display.html:117
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:177
 msgid "Producer"
 msgstr ""
@@ -253,12 +253,12 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:628
+#: udata_front/theme/gouvfr/templates/dataset/display.html:634
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:206
 msgid "Embed"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:567
+#: udata_front/theme/gouvfr/templates/dataset/display.html:568
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:209
 msgid "Temporal coverage"
 msgstr ""
@@ -275,7 +275,7 @@ msgstr ""
 msgid "Territory"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:562
+#: udata_front/theme/gouvfr/templates/dataset/display.html:563
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:232
 msgid "Frequency"
 msgstr ""
@@ -420,7 +420,7 @@ msgstr ""
 msgid "All news"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:38
+#: udata_front/theme/gouvfr/templates/dataset/display.html:39
 #: udata_front/theme/gouvfr/templates/dataset/followers.html:6
 #: udata_front/theme/gouvfr/templates/dataset/list.html:8
 #: udata_front/theme/gouvfr/templates/dataset/list.html:14
@@ -439,8 +439,8 @@ msgstr ""
 msgid "Datasets"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:197
-#: udata_front/theme/gouvfr/templates/dataset/display.html:270
+#: udata_front/theme/gouvfr/templates/dataset/display.html:198
+#: udata_front/theme/gouvfr/templates/dataset/display.html:271
 #: udata_front/theme/gouvfr/templates/home.html:83
 msgid "Files"
 msgstr ""
@@ -458,8 +458,8 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:230
-#: udata_front/theme/gouvfr/templates/dataset/display.html:290
+#: udata_front/theme/gouvfr/templates/dataset/display.html:231
+#: udata_front/theme/gouvfr/templates/dataset/display.html:291
 #: udata_front/theme/gouvfr/templates/home.html:87
 #: udata_front/theme/gouvfr/templates/reuse/display.html:184
 msgid "Discussions"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "RSS - new tab"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:627
+#: udata_front/theme/gouvfr/templates/dataset/display.html:633
 #: udata_front/theme/gouvfr/templates/page.html:52
 #: udata_front/theme/gouvfr/templates/post/display.html:95
 msgid "Actions"
@@ -596,7 +596,7 @@ msgid "Maintainer"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/api/admin.html:31
-#: udata_front/theme/gouvfr/templates/dataset/display.html:58
+#: udata_front/theme/gouvfr/templates/dataset/display.html:59
 #: udata_front/theme/gouvfr/templates/post/display.html:102
 #: udata_front/theme/gouvfr/templates/reuse/display.html:62
 #: udata_front/theme/gouvfr/templates/user/base.html:46
@@ -683,7 +683,7 @@ msgstr ""
 #: udata_front/theme/gouvfr/templates/dataset/card-lg.html:10
 #: udata_front/theme/gouvfr/templates/dataset/card-sm.html:9
 #: udata_front/theme/gouvfr/templates/dataset/card-xs.html:10
-#: udata_front/theme/gouvfr/templates/dataset/display.html:75
+#: udata_front/theme/gouvfr/templates/dataset/display.html:76
 #: udata_front/theme/gouvfr/templates/reuse/card.html:11
 #: udata_front/theme/gouvfr/templates/reuse/display.html:79
 msgid "Private"
@@ -692,7 +692,7 @@ msgstr ""
 #: udata_front/theme/gouvfr/templates/dataset/card-lg.html:16
 #: udata_front/theme/gouvfr/templates/dataset/card-sm.html:15
 #: udata_front/theme/gouvfr/templates/dataset/card-xs.html:16
-#: udata_front/theme/gouvfr/templates/dataset/display.html:92
+#: udata_front/theme/gouvfr/templates/dataset/display.html:93
 msgid "Archived"
 msgstr ""
 
@@ -723,51 +723,51 @@ msgid_plural "<strong class=\"fr-mr-1v\">%(num)d</strong> favorites"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:16
+#: udata_front/theme/gouvfr/templates/dataset/display.html:17
 msgid "dataset"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:22
+#: udata_front/theme/gouvfr/templates/dataset/display.html:23
 #: udata_front/theme/gouvfr/templates/reuse/display.html:18
 #, python-format
 msgid "Explore with %(certifier)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:75
+#: udata_front/theme/gouvfr/templates/dataset/display.html:76
 msgid "This dataset is private and will not be visible by other users"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:82
+#: udata_front/theme/gouvfr/templates/dataset/display.html:83
 msgid "This dataset has been deleted. This will be permanent in the next 24 hours"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:82
+#: udata_front/theme/gouvfr/templates/dataset/display.html:83
 #: udata_front/theme/gouvfr/templates/organization/display.html:67
 #: udata_front/theme/gouvfr/templates/reuse/display.html:86
 msgid "Deleted"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:87
+#: udata_front/theme/gouvfr/templates/dataset/display.html:88
 msgid ""
 "This dataset has been archived automatically because it has been deleted from"
 " the remote platform."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:89
+#: udata_front/theme/gouvfr/templates/dataset/display.html:90
 msgid "This dataset has been archived."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:104
+#: udata_front/theme/gouvfr/templates/dataset/display.html:105
 #: udata_front/theme/gouvfr/templates/organization/display.html:195
 #: udata_front/theme/gouvfr/templates/reuse/display.html:109
 msgid "Description"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:121
+#: udata_front/theme/gouvfr/templates/dataset/display.html:122
 msgid "Author"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:126
+#: udata_front/theme/gouvfr/templates/dataset/display.html:127
 #, python-format
 msgid ""
 "This dataset has been published on the initiative and under the "
@@ -776,13 +776,13 @@ msgid ""
 "%(update)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:138
+#: udata_front/theme/gouvfr/templates/dataset/display.html:139
 msgid ""
 "This dataset come from an external portal.&nbsp;<a "
 "href='{external_source}'>View the original source.</a>"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:146
+#: udata_front/theme/gouvfr/templates/dataset/display.html:147
 msgid ""
 "This dataset is handled by the <a href='{geo_link}'>geo.data.gouv.fr</a> "
 "platform.\n"
@@ -792,146 +792,147 @@ msgid ""
 "geo.data.gouv.fr is available here.</a>"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:157
-#: udata_front/theme/gouvfr/templates/dataset/display.html:573
+#: udata_front/theme/gouvfr/templates/dataset/display.html:158
+#: udata_front/theme/gouvfr/templates/dataset/display.html:574
 #: udata_front/theme/gouvfr/templates/organization/display.html:345
 msgid "Latest update"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:162
-#: udata_front/theme/gouvfr/templates/dataset/display.html:538
+#: udata_front/theme/gouvfr/templates/dataset/display.html:163
+#: udata_front/theme/gouvfr/templates/dataset/display.html:539
 msgid "License"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:180
-#: udata_front/theme/gouvfr/templates/dataset/display.html:262
+#: udata_front/theme/gouvfr/templates/dataset/display.html:181
+#: udata_front/theme/gouvfr/templates/dataset/display.html:263
 #: udata_front/theme/gouvfr/templates/organization/display.html:78
 #: udata_front/theme/gouvfr/templates/organization/display.html:146
 msgid "In-page navigation"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:244
-#: udata_front/theme/gouvfr/templates/dataset/display.html:300
+#: udata_front/theme/gouvfr/templates/dataset/display.html:245
+#: udata_front/theme/gouvfr/templates/dataset/display.html:301
 msgid "Community resources"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:258
-#: udata_front/theme/gouvfr/templates/dataset/display.html:310
-#: udata_front/theme/gouvfr/templates/dataset/display.html:519
+#: udata_front/theme/gouvfr/templates/dataset/display.html:259
+#: udata_front/theme/gouvfr/templates/dataset/display.html:311
+#: udata_front/theme/gouvfr/templates/dataset/display.html:520
 #: udata_front/theme/gouvfr/templates/organization/display.html:142
 #: udata_front/theme/gouvfr/templates/organization/display.html:182
 msgid "Information"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:354
+#: udata_front/theme/gouvfr/templates/dataset/display.html:355
 #, python-format
 msgid "See the %(type)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:362
+#: udata_front/theme/gouvfr/templates/dataset/display.html:363
 msgid "There are no files for this dataset yet."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:370
+#: udata_front/theme/gouvfr/templates/dataset/display.html:371
 msgid "Add a file"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:391
+#: udata_front/theme/gouvfr/templates/dataset/display.html:392
 #, python-format
 msgid "%(num)d Reuse"
 msgid_plural "%(num)d Reuses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:396
+#: udata_front/theme/gouvfr/templates/dataset/display.html:397
 msgid "Add a reuse"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:413
+#: udata_front/theme/gouvfr/templates/dataset/display.html:414
 msgid "There are no reuses for this dataset yet."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:420
+#: udata_front/theme/gouvfr/templates/dataset/display.html:421
 msgid "Publish a reuse"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:426
+#: udata_front/theme/gouvfr/templates/dataset/display.html:427
 #: udata_front/theme/gouvfr/templates/organization/display.html:293
 msgid "What's a reuse ?"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:445
+#: udata_front/theme/gouvfr/templates/dataset/display.html:446
 msgid "There are no discussions for this dataset yet."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:469
+#: udata_front/theme/gouvfr/templates/dataset/display.html:470
 msgid ""
 "These resources are published by the community and the producer isn't "
 "responsible for them."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:476
+#: udata_front/theme/gouvfr/templates/dataset/display.html:477
 #, python-format
 msgid "%(num)d Community resource"
 msgid_plural "%(num)d Community resources"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:491
+#: udata_front/theme/gouvfr/templates/dataset/display.html:492
 msgid "There are no community resources for this dataset yet."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:498
+#: udata_front/theme/gouvfr/templates/dataset/display.html:499
 msgid "Share your resources"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:504
+#: udata_front/theme/gouvfr/templates/dataset/display.html:505
 msgid "Learn more about the community"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:520
+#: udata_front/theme/gouvfr/templates/dataset/display.html:521
 #: udata_front/theme/gouvfr/templates/reuse/display.html:148
 msgid "Tags"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:546
+#: udata_front/theme/gouvfr/templates/dataset/display.html:547
 #: udata_front/theme/gouvfr/templates/organization/display.html:348
 msgid "ID"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:550
+#: udata_front/theme/gouvfr/templates/dataset/display.html:551
 msgid "Remote source"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:556
+#: udata_front/theme/gouvfr/templates/dataset/display.html:557
 msgid "Temporality"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:558
+#: udata_front/theme/gouvfr/templates/dataset/display.html:559
 msgid "Creation"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:579
+#: udata_front/theme/gouvfr/templates/dataset/display.html:580
 msgid "Spatial coverage"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:582
+#: udata_front/theme/gouvfr/templates/dataset/display.html:583
+#: udata_front/theme/gouvfr/templates/dataset/display.html:590
 msgid "Territorial coverage"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:589
+#: udata_front/theme/gouvfr/templates/dataset/display.html:595
 msgid "Territorial coverage granularity"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:598
+#: udata_front/theme/gouvfr/templates/dataset/display.html:604
 msgid "Data schema"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:603
+#: udata_front/theme/gouvfr/templates/dataset/display.html:609
 msgid "The dataset files are following the schema: "
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:609
+#: udata_front/theme/gouvfr/templates/dataset/display.html:615
 msgid ""
 "Schemas allow to describe data models,\n"
 "                                discover how schemas improve your data "
@@ -939,24 +940,24 @@ msgid ""
 "                                on <a href=\"{url}\">schema.data.gouv.fr</a>"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:620
+#: udata_front/theme/gouvfr/templates/dataset/display.html:626
 #: udata_front/theme/gouvfr/templates/dataset/resource/card.html:131
 msgid "See schema documentation"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:633
+#: udata_front/theme/gouvfr/templates/dataset/display.html:639
 msgid "Extras"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:642
+#: udata_front/theme/gouvfr/templates/dataset/display.html:648
 msgid "See extras"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:661
+#: udata_front/theme/gouvfr/templates/dataset/display.html:667
 msgid "Harvest"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:670
+#: udata_front/theme/gouvfr/templates/dataset/display.html:676
 msgid "See harvest extras"
 msgstr ""
 
@@ -1233,7 +1234,7 @@ msgid "Data description filled"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/quality_score_toggletip.html:14
-#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:18
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:24
 msgid "Data description empty"
 msgstr ""
 
@@ -1242,7 +1243,7 @@ msgid "Files documented"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/quality_score_toggletip.html:20
-#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:23
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:29
 msgid "Files documentation missing"
 msgstr ""
 
@@ -1251,7 +1252,7 @@ msgid "License filled"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/quality_score_toggletip.html:26
-#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:28
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:34
 msgid "No license set"
 msgstr ""
 
@@ -1260,12 +1261,12 @@ msgid "Update frequency followed"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/quality_score_toggletip.html:32
-#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:33
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:39
 msgid "Update frequency not followed"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/quality_score_toggletip.html:32
-#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:33
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:39
 msgid "Update frequency not set"
 msgstr ""
 
@@ -1274,7 +1275,7 @@ msgid "File formats are open"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/quality_score_toggletip.html:38
-#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:38
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:44
 msgid "File formats are closed"
 msgstr ""
 
@@ -1283,7 +1284,7 @@ msgid "Temporal coverage filled"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/quality_score_toggletip.html:44
-#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:43
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:49
 msgid "Temporal coverage not set"
 msgstr ""
 
@@ -1292,7 +1293,7 @@ msgid "Spatial coverage filled"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/quality_score_toggletip.html:50
-#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:48
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:54
 msgid "Spatial coverage not set"
 msgstr ""
 
@@ -1301,7 +1302,7 @@ msgid "All files are available"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/quality_score_toggletip.html:56
-#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:53
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:59
 msgid "Some files are unavailable"
 msgstr ""
 
@@ -1316,6 +1317,12 @@ msgstr ""
 #: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:9
 #: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:12
 msgid "Metadata quality"
+msgstr ""
+
+#: udata_front/theme/gouvfr/templates/macros/quality_score_with_warning_below.html:19
+msgid ""
+"Metadata quality may be misleading since metadata info may have been lost "
+"from original source"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/search.html:17


### PR DESCRIPTION
This is a proposal to start harvesting some plateforms (ex with https://github.com/opendatateam/udata/pull/2957) without penalizing them due to harvest issues.
Indeed, if quality errors shows prominently, some producers won't want to be harvested.
We could remove this when we're sure the quality issues are no more the consequences of the harvest mapping.

It would show like this on a Dataset page:
![image](https://github.com/etalab/udata-front/assets/28541902/49bb83fa-fecf-4306-9896-bcd2c0261da3)
Detailed items are still available in the toggle, but not warning shown directly.

On the Dataset card, the quality metadata would simply not be shown.
![image](https://github.com/etalab/udata-front/assets/28541902/82967139-851f-4a33-9bae-bc05ab2ee148)

What do you think @agarrone?
