### PR TITLE
Add vite config for dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Show error when dataset discussion from url doesn't exist [#367](https://github.com/etalab/udata-front/pull/367)
+- Add a new vite config for development [#372](https://github.com/etalab/udata-front/pull/372)
 
 ## 3.5.3 (2024-02-22)
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "name": "Etalab"
   },
   "scripts": {
-    "dev": "vite build --watch",
+    "dev": "vite build --watch --config vite.config.dev.ts",
     "start": "npm run dev",
     "build": "vite build",
     "test": "cypress run",

--- a/vite.config.dev.ts
+++ b/vite.config.dev.ts
@@ -1,0 +1,75 @@
+import { defineConfig, type UserConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import copy from 'rollup-plugin-copy';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'url';
+import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite';
+import { getTheme, getVersion } from "./vite.config";
+
+async function getConfig(): Promise<UserConfig> {
+  const theme = getTheme();
+  let version = await getVersion(process.env.buildno);
+
+  return {
+    base: `/_themes/${theme}/`,
+    plugins: [
+      vue(),
+      VueI18nPlugin({
+        compositionOnly: false,
+        /* options */
+        include: resolve(dirname(fileURLToPath(import.meta.url)), `udata_front/theme/${theme}/assets/js/locales/**`),
+      }),
+      copy({
+        targets: [
+          { src: `udata_front/theme/${theme}/assets/img`, dest: `udata_front/theme/${theme}/static/` },
+          { src: "node_modules/leaflet/dist/leaflet.js", dest: `udata_front/theme/${theme}/static/js/` },
+          { src: "node_modules/leaflet/dist/leaflet.css", dest: `udata_front/theme/${theme}/static/js/` },
+          {
+            src: "node_modules/es-module-shims/dist/es-module-shims.js",
+            dest: `udata_front/theme/${theme}/static/js/`,
+            rename: `es-module-shims.${version}.js`,
+          },
+          {
+            src: "node_modules/vue/dist/vue.esm-browser.js",
+            dest: `udata_front/theme/${theme}/static/js/`,
+            rename: `vue.esm-browser.prod.${version}.js`,
+          },
+          {
+            src: "node_modules/vue-content-loader/dist/vue-content-loader.es.js",
+            dest: `udata_front/theme/${theme}/static/js/`,
+            rename: `vue-content-loader.es.${version}.js`,
+          },
+        ],
+        hook: 'writeBundle'
+      }),
+    ],
+    build: {
+      rollupOptions: {
+        input: [
+          `udata_front/theme/${theme}/assets/js/index.ts`,
+          `udata_front/theme/${theme}/assets/js/admin.ts`,
+          `udata_front/theme/${theme}/assets/less/style.less`,
+        ],
+        preserveEntrySignatures: 'exports-only',
+        // make sure to externalize deps that shouldn't be bundled
+        // into your library
+        external: ['vue', 'vue-content-loader'],
+        output: {
+          dir: `./udata_front/theme/${theme}/static/`,
+          entryFileNames: `js/[name].${version}.js`,
+          chunkFileNames: `js/[name].${version}.js`,
+          assetFileNames: `assets/[name].[ext]`,
+          // Provide global variables to use in the UMD build
+          // for externalized deps
+          globals: {
+            vue: 'Vue',
+            "vue-content-loader": "ContentLoader"
+          }
+        }
+      }
+    }
+  };
+}
+
+// https://vitejs.dev/config/
+export default defineConfig(getConfig());


### PR DESCRIPTION
This PR adds a vite config for development only.
It removes the legacy plugin and the bundling of external dependencies.
It also uses a development build of vue instead of the production one.