### PR TITLE
Unpin udata version in setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Current (in progress)
 
 - Move Pagination to datagouv-components [#365](https://github.com/etalab/udata-front/pull/365)
-- Fix release CI [#380](https://github.com/etalab/udata-front/pull/380)
+- Fix release CI [#380](https://github.com/etalab/udata-front/pull/380) [#384](https://github.com/etalab/udata-front/pull/384)
 - Add stories to Resource component [#364](https://github.com/etalab/udata-front/pull/364)
 - Move Well to datagouv-components [#382](https://github.com/etalab/udata-front/pull/382)
 - Add markdown editor [#351](https://github.com/etalab/udata-front/pull/351)

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,9 @@ def file_content(filename):
 
 
 def get_requirements():
-    '''Return content of pip requirements file with very custom logic'''
-    reqs = file_content(os.path.join('requirements', 'udata.pip')).splitlines()
-    # keep only the ref to udata, unpinned if not udata==xxx
-    reqs = [r for r in reqs if r.strip().startswith('udata==')] or ['udata']
+    '''Return content of pip requirement file and add udata'''
+    # unpinned udata requirement
+    reqs = ['udata']
     reqs += file_content(os.path.join('requirements', 'install.pip')).splitlines()
     return reqs
 


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/1328

In https://github.com/etalab/udata-gouvfr/pull/626, the `install_requires` of setup.py used a pinned version of udata if defined.
It prevents installing udata-front with any other working udata versions.

It was meant to be used in the release instead of the udata.git.
However, the version used to build the udata-front release shouldn't be added as a fixed dep in `install_requires` udata-front, but should only be used to install deps.

The latest release is already used in CI by replacing the [dep to udata.git git by `udata`](https://github.com/etalab/udata-front/blob/1cc30c449082aa22fe2bafe4cc46c268c31fa797/.circleci/config.yml#L35).
We then apply
```
pip-compile requirements/udata.in --output-file=requirements/udata.pip
...
pip install -r requirements/udata.pip
```
We're correctly using the latest udata release at this point (https://github.com/etalab/udata-front/pull/363).

Historically, udata wasn't pinned to a specific version ([v3.1.3](https://pypi.org/pypi/udata-front/3.1.3/json), [v2.0.0](https://pypi.org/pypi/udata-front/2.0.0/json) (see `info > requires_dist`)).

Thus, let's remove the udata pinned version in the `install_requires` in setup.py