### PR TITLE
fix: display the organization's reuses by publishing date

### DIFF
--- a/udata_front/views/organization.py
+++ b/udata_front/views/organization.py
@@ -90,7 +90,7 @@ class OrganizationDetailView(SearchView, OrgView, DetailView):
 
         reuses = Reuse.objects(
             organization=self.organization).order_by(
-            '-metrics.reuses', '-metrics.followers')
+            '-created_at')
 
         followers = (Follow.objects.followers(self.organization)
                      .order_by('follower.fullname'))


### PR DESCRIPTION
Close https://github.com/etalab/data.gouv.fr/issues/1334