### PR TITLE
Fix failing captchetat responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Upgrade vue dependency [#386](https://github.com/etalab/udata-front/pull/386)
 - Add codes and optgroups in Multiselect to display Insee codes and Licence groups [#347] (https://github.com/etalab/udata-front/pull/347)
 - Order Organization's reuses by publishing date [#390](https://github.com/etalab/udata-front/pull/390)
+- Fix failing captchEtat responses [#392](https://github.com/etalab/udata-front/pull/392)
 
 ## 3.5.4 (2024-03-20)
 

--- a/udata_front/api.py
+++ b/udata_front/api.py
@@ -72,11 +72,6 @@ class CaptchEtatAPI(API):
         except requests.exceptions.RequestException:
             abort(500, description='Catptcha internal error')
 
-        if args['get'] in ['image', 'sound']:
-            resp = make_response(bytes(req.content))
-            resp.headers['Content-Type'] = 'image/*' if args['get'] == 'image' else 'audio/x-wav'
-            return resp
-        if args['get'] == "p":
-            return json.loads(req.content)
-
-        return req.content
+        resp = make_response(bytes(req.content))
+        resp.headers['Content-Type'] = req.headers.get('Content-Type')
+        return resp

--- a/udata_front/api.py
+++ b/udata_front/api.py
@@ -1,4 +1,4 @@
-from flask import current_app, json, make_response, abort
+from flask import current_app, make_response, abort
 
 import logging
 import requests

--- a/udata_front/tests/test_api.py
+++ b/udata_front/tests/test_api.py
@@ -49,10 +49,12 @@ class ApiTest(WebTestMixin):
         rmock.post(self.oauth_token_url(), json={"access_token": "some_token", "expires_in": 3600})
         rmock.get(
             self.captchetat_url() + "?get=html&c=" + style,
-            text=f"some HTML with {style} and {self.captcha_id}"
+            text=f"some HTML with {style} and {self.captcha_id}",
+            headers={"Content-Type": "text/html;charset=utf-8"}
         )
         response = self.get(url_for('apiv2.captchetat', get='html', c=style))
         self.assert200(response)
+        assert response.content_type == "text/html;charset=utf-8"
         snippet = response.data.decode('utf8')
         assert style in snippet
         assert self.captcha_id in snippet
@@ -65,9 +67,11 @@ class ApiTest(WebTestMixin):
         rmock.post(self.oauth_token_url(), json={"access_token": "some_token", "expires_in": 3600})
         content = bytes("some string", 'UTF-8')
         rmock.get(f"{self.captchetat_url()}?get=image&c={style}&t={self.captcha_id}",
-                  content=content)
+                  content=content,
+                  headers={"Content-Type": "image/png"})
         response = self.get(url_for('apiv2.captchetat', get='image', c=style, t=self.captcha_id))
         self.assert200(response)
+        assert response.content_type == "image/png"
         assert content in bytes(response.data)
 
     @pytest.mark.options(CAPTCHETAT_OAUTH_BASE_URL=oauth_url)
@@ -78,7 +82,8 @@ class ApiTest(WebTestMixin):
         rmock.post(self.oauth_token_url(), json={"access_token": "some_token", "expires_in": 3600})
         content = bytes(10)
         rmock.get(f"{self.captchetat_url()}?get=sound&c={style}&t={self.captcha_id}",
-                  content=content)
+                  content=content,
+                  headers={"Content-Type": "audio/x-wav"})
         response = self.get(
             url_for('apiv2.captchetat', get='sound', c=style, t=self.captcha_id),
             content_type="audio/*"
@@ -93,7 +98,9 @@ class ApiTest(WebTestMixin):
         '''It should return json additional data from the service.'''
         rmock.post(self.oauth_token_url(), json={"access_token": "some_token", "expires_in": 3600})
         json = {"hs": "some_id", "sp": "another_id"}
-        rmock.get(f"{self.captchetat_url()}?get=p&c={style}&t={self.captcha_id}", json=json)
+        rmock.get(f"{self.captchetat_url()}?get=p&c={style}&t={self.captcha_id}",
+                  json=json,
+                  headers={"Content-Type": "application/json"})
         response = self.get(url_for('apiv2.captchetat', get='p', c=style, t=self.captcha_id))
         self.assert200(response)
         assert response.content_type == "application/json"


### PR DESCRIPTION
See failing tests in https://app.circleci.com/pipelines/github/etalab/udata-front/3411/workflows/789166fd-c91e-4c3b-82f1-32b508f3882e/jobs/17989.

Indeed, if no Content-Type is set on response, flask_restx expects it to be application/json.
It ends up [wrongfully calling json `dumps()`](https://github.com/python-restx/flask-restx/blob/b38a7d993b3e075feff1bc0af154695b285b6ea2/flask_restx/representations.py#L9) on req.content, which will be bytes.

Even if unexpected, it wasn't failing until then thanks to `ujson`.
`ujson` having been removed since https://github.com/opendatateam/udata/pull/3006/, it now fallbacks on json in [flask_restx make response](https://github.com/python-restx/flask-restx/blob/b38a7d993b3e075feff1bc0af154695b285b6ea2/flask_restx/representations.py#L1).
`json.dumps(b'some bytes')` now fails, on contrary to `ujson.dumps(b'some bytes')`.
We may want to reintroduce ujson for performance reasons, but should probably not apply a json dump on bytes output in any case: https://github.com/ultrajson/ultrajson/issues/264.

To prevent dumping the content, we make sure to build the response explicitly and associate it with upstream captchetat Content-Type.